### PR TITLE
Fix major release blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version                                                              | Notes                                                                                                                                            |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [**5.0.0**](https://github.com/elm-explorations/elm-test/tree/5.0.0) | Update for Elm 0.19. Remove `Fuzz.andThen` and `Test.Runner.getFailure`.                                                                         |
+| [**5.0.0**](https://github.com/elm-explorations/elm-test/tree/5.0.0) | Update for Elm 0.19. Remove `Fuzz.andThen` and `Test.Runner.getFailure`. Fail on equating floats to encourage checks with tolerance.             |
 | [**4.0.0**](https://github.com/elm-explorations/elm-test/tree/4.0.0) | Add `only`, `skip`, `todo`; change `Fuzz.frequency` to fail rather than crash on bad input, disallow tests with blank or duplicate descriptions. |
 | [**3.1.0**](https://github.com/elm-explorations/elm-test/tree/3.1.0) | Add `Expect.all`                                                                                                                                 |
 | [**3.0.0**](https://github.com/elm-explorations/elm-test/tree/3.0.0) | Update for Elm 0.18; switch the argument order of `Fuzz.andMap`.                                                                                 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 | Version                                                              | Notes                                                                                                                                            |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [**5.0.0**](https://github.com/elm-explorations/elm-test/tree/5.0.0) | Update for Elm 0.19. Remove `Fuzz.andThen` and `Test.Runner.getFailure`. Fail on equating floats to encourage checks with tolerance.             |
-| [**4.0.0**](https://github.com/elm-explorations/elm-test/tree/4.0.0) | Add `only`, `skip`, `todo`; change `Fuzz.frequency` to fail rather than crash on bad input, disallow tests with blank or duplicate descriptions. |
-| [**3.1.0**](https://github.com/elm-explorations/elm-test/tree/3.1.0) | Add `Expect.all`                                                                                                                                 |
-| [**3.0.0**](https://github.com/elm-explorations/elm-test/tree/3.0.0) | Update for Elm 0.18; switch the argument order of `Fuzz.andMap`.                                                                                 |
-| [**2.1.0**](https://github.com/elm-explorations/elm-test/tree/2.1.0) | Switch to rose trees for `Fuzz.andThen`, other API additions.                                                                                    |
-| [**2.0.0**](https://github.com/elm-explorations/elm-test/tree/2.0.0) | Scratch-rewrite to project-fuzzball                                                                                                              |
-| [**1.0.0**](https://github.com/elm-explorations/elm-test/tree/1.0.0) | ElmTest initial release                                                                                                                          |
+| [**1.0.0**](https://github.com/elm-explorations/test/tree/1.0.0) | Update for Elm 0.19. Remove `Fuzz.andThen` and `Test.Runner.getFailure`. Fail on equating floats to encourage checks with tolerance.             |
+| renamed from **elm-community/elm-test** (below) to **elm-explorations/test** (above) | |
+| [**4.0.0**](https://github.com/elm-community/elm-test/tree/4.0.0) | Add `only`, `skip`, `todo`; change `Fuzz.frequency` to fail rather than crash on bad input, disallow tests with blank or duplicate descriptions. |
+| [**3.1.0**](https://github.com/elm-community/elm-test/tree/3.1.0) | Add `Expect.all`                                                                                                                                 |
+| [**3.0.0**](https://github.com/elm-community/elm-test/tree/3.0.0) | Update for Elm 0.18; switch the argument order of `Fuzz.andMap`.                                                                                 |
+| [**2.1.0**](https://github.com/elm-community/elm-test/tree/2.1.0) | Switch to rose trees for `Fuzz.andThen`, other API additions.                                                                                    |
+| [**2.0.0**](https://github.com/elm-community/elm-test/tree/2.0.0) | Scratch-rewrite to project-fuzzball                                                                                                              |
+| [**1.0.0**](https://github.com/elm-community/elm-test/tree/1.0.0) | ElmTest initial release                                                                                                                          |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Releases
-| Version | Notes |
-| ------- | ----- |
-| [**5.0.0**](https://github.com/elm-explorations/elm-test/tree/4.0.0) | Remove `Fuzz.andThen`.
-| [**4.0.0**](https://github.com/elm-explorations/elm-test/tree/4.0.0) | Add `only`, `skip`, `todo`; change `Fuzz.frequency` to fail rather than crash on bad input, disallow tests with blank or duplicate descriptions.
-| [**3.1.0**](https://github.com/elm-explorations/elm-test/tree/3.1.0) | Add `Expect.all`
-| [**3.0.0**](https://github.com/elm-explorations/elm-test/tree/3.0.0) | Update for Elm 0.18; switch the argument order of `Fuzz.andMap`.
-| [**2.1.0**](https://github.com/elm-explorations/elm-test/tree/2.1.0) | Switch to rose trees for `Fuzz.andThen`, other API additions.
-| [**2.0.0**](https://github.com/elm-explorations/elm-test/tree/2.0.0) | Scratch-rewrite to project-fuzzball
-| [**1.0.0**](https://github.com/elm-explorations/elm-test/tree/1.0.0) | ElmTest initial release
+
+| Version                                                              | Notes                                                                                                                                            |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [**5.0.0**](https://github.com/elm-explorations/elm-test/tree/5.0.0) | Update for Elm 0.19. Remove `Fuzz.andThen` and `Test.Runner.getFailure`.                                                                         |
+| [**4.0.0**](https://github.com/elm-explorations/elm-test/tree/4.0.0) | Add `only`, `skip`, `todo`; change `Fuzz.frequency` to fail rather than crash on bad input, disallow tests with blank or duplicate descriptions. |
+| [**3.1.0**](https://github.com/elm-explorations/elm-test/tree/3.1.0) | Add `Expect.all`                                                                                                                                 |
+| [**3.0.0**](https://github.com/elm-explorations/elm-test/tree/3.0.0) | Update for Elm 0.18; switch the argument order of `Fuzz.andMap`.                                                                                 |
+| [**2.1.0**](https://github.com/elm-explorations/elm-test/tree/2.1.0) | Switch to rose trees for `Fuzz.andThen`, other API additions.                                                                                    |
+| [**2.0.0**](https://github.com/elm-explorations/elm-test/tree/2.0.0) | Scratch-rewrite to project-fuzzball                                                                                                              |
+| [**1.0.0**](https://github.com/elm-explorations/elm-test/tree/1.0.0) | ElmTest initial release                                                                                                                          |

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -161,6 +161,8 @@ which argument is which:
 
     -}
 
+Do not equate `Float` values; use [`within`](#within) instead.
+
 -}
 equal : a -> a -> Expectation
 equal =
@@ -217,6 +219,8 @@ which argument is which:
     -1
 
     -}
+
+Do not equate `Float` values; use [`notWithin`](#notWithin) instead.
 
 -}
 lessThan : comparable -> comparable -> Expectation
@@ -754,8 +758,34 @@ reportCollectionFailure comparison expected actual missingKeys extraKeys =
 {-| String arg is label, e.g. "Expect.equal".
 -}
 equateWith : String -> (a -> b -> Bool) -> b -> a -> Expectation
-equateWith =
-    testWith Equality
+equateWith reason comparison b a =
+    let
+        isJust x =
+            case x of
+                Just _ ->
+                    True
+
+                Nothing ->
+                    False
+
+        isFloat x =
+            isJust (String.toFloat x) && not (isJust (String.toInt x))
+
+        usesFloats =
+            isFloat (Internal.toString a) || isFloat (Internal.toString b)
+
+        floatError =
+            if String.contains reason "not" then
+                "Do not use Expect.notEqual with floats. Use Float.notWithin instead."
+
+            else
+                "Do not use Expect.equal with floats. Use Float.within instead."
+    in
+    if usesFloats then
+        fail floatError
+
+    else
+        testWith Equality reason comparison b a
 
 
 compareWith : String -> (a -> b -> Bool) -> b -> a -> Expectation

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -6,7 +6,6 @@ module Test.Runner
         , formatLabels
         , fromTest
         , fuzz
-        , getFailure
         , getFailureReason
         , isTodo
         , shrink
@@ -25,7 +24,7 @@ can be found in the `README`.
 
 ## Expectations
 
-@docs getFailure, getFailureReason, isTodo
+@docs getFailureReason, isTodo
 
 
 ## Formatting
@@ -358,38 +357,6 @@ fnvHashString hash str =
 fnvHash : Int -> Int -> Int
 fnvHash a b =
     Bitwise.xor a b * 16777619 |> Bitwise.shiftRightZfBy 0
-
-
-{-| **DEPRECATED.** Please use [`getFailureReason`](#getFailureReason) instead.
-This function will be removed in the next major version.
-
-Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).
-
-If it is a [`fail`](#fail), return a record containing the failure message,
-along with the given inputs if it was a fuzz test. (If no inputs were involved,
-the record's `given` field will be `Nothing`).
-
-For example, if a fuzz test generates random integers, this might return
-`{ message = "it was supposed to be positive", given = "-1" }`
-
-    getFailure (Expect.fail "this failed")
-    -- Just { message = "this failed", given = "" }
-
-    getFailure (Expect.pass)
-    -- Nothing
-
--}
-getFailure : Expectation -> Maybe { given : Maybe String, message : String }
-getFailure expectation =
-    case expectation of
-        Test.Expectation.Pass ->
-            Nothing
-
-        Test.Expectation.Fail { given, description, reason } ->
-            Just
-                { given = given
-                , message = Test.Runner.Failure.format description reason
-                }
 
 
 {-| Return `Nothing` if the given [`Expectation`](#Expectation) is a [`pass`](#pass).

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,5 +2,4 @@
 
 1. `cd` into this directory
 2. `npm install`
-3. `elm package install --yes`
-4. `npm test`
+3. `npm test`

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -70,6 +70,13 @@ expectationTests =
                 test "fails with empty list" <|
                     \_ -> "dummy subject" |> Expect.all []
             ]
+        , describe "Expect.equal"
+            [ expectToFail <|
+                test "fails when equating two floats (see #230)" <|
+                    \_ -> 1.41 |> Expect.equal 1.41
+            , test "succeeds when equating two ints" <|
+                \_ -> 141 |> Expect.equal 141
+            ]
         ]
 
 


### PR DESCRIPTION
As asked on Slack, here are fixes for issues tagged major-release-blocker in the main repo.

There is also mention in 191 (no link for stealth) of removing `Fuzz.conditional`. This is a pretty clunky filtering system that I don't think we should encourage. Anyone feel strongly in favor of keeping it?