### PR TITLE
Fix formatting of doc comment for Fuzz.andThen

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -525,12 +525,12 @@ map5 transform fuzzA fuzzB fuzzC fuzzD fuzzE =
     (Result.map5 << Random.map5 << map5RoseTree) transform fuzzA fuzzB fuzzC fuzzD fuzzE
 
 
-{-| Map over many fuzzers. This can act as mapN for N > 5.
+{-| Map over many fuzzers. This can act as `mapN` for `N > 5`.
 The argument order is meant to accommodate chaining:
-map f aFuzzer
-|> andMap anotherFuzzer
-|> andMap aThirdFuzzer
-Note that shrinking may be better using mapN.
+    map f aFuzzer
+    |> andMap anotherFuzzer
+    |> andMap aThirdFuzzer
+Note that shrinking may be better using `mapN`.
 -}
 andMap : Fuzzer a -> Fuzzer (a -> b) -> Fuzzer b
 andMap =

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -527,10 +527,13 @@ map5 transform fuzzA fuzzB fuzzC fuzzD fuzzE =
 
 {-| Map over many fuzzers. This can act as `mapN` for `N > 5`.
 The argument order is meant to accommodate chaining:
+
     map f aFuzzer
-    |> andMap anotherFuzzer
-    |> andMap aThirdFuzzer
+        |> andMap anotherFuzzer
+        |> andMap aThirdFuzzer
+
 Note that shrinking may be better using `mapN`.
+
 -}
 andMap : Fuzzer a -> Fuzzer (a -> b) -> Fuzzer b
 andMap =


### PR DESCRIPTION
Adds back ticks and indents the example to ensure correct rendering.

Hopefully, this will make the doc a bit easier to read 😄 