### PR TITLE
Remove note on random not being from core

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -67,9 +67,8 @@ type alias Fuzzer a =
 
 
 {-| Build a custom `Fuzzer a` by providing a `Generator a` and a `Shrinker a`.
-Generators are defined in [`elm/random`](http://package.elm-lang.org/packages/elm/random/latest),
-which is not core's Random module but has a compatible interface. Shrinkers are
-defined in [`eeue56/elm-shrink`](http://package.elm-lang.org/packages/eeue56/elm-shrink/latest/).
+Generators are defined in [`elm/random`](http://package.elm-lang.org/packages/elm/random/latest).
+Shrinkers are defined in [`eeue56/elm-shrink`](http://package.elm-lang.org/packages/eeue56/elm-shrink/latest/).
 
 Here is an example for a record:
 


### PR DESCRIPTION
The docs of the `custom` fuzzer method seem to be outdated. I did not find anything with "random" in the [core package](https://package.elm-lang.org/packages/elm/core/latest/).

Therefore I propose to remove that sentence.