### PR TITLE
Remove link to external shrinkers

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -68,8 +68,7 @@ type alias Fuzzer a =
 
 {-| Build a custom `Fuzzer a` by providing a `Generator a` and a `Shrinker a`.
 Generators are defined in [`elm/random`](http://package.elm-lang.org/packages/elm/random/latest),
-which is not core's Random module but has a compatible interface. Shrinkers are
-defined in [`eeue56/elm-shrink`](http://package.elm-lang.org/packages/eeue56/elm-shrink/latest/).
+which is not core's Random module but has a compatible interface.
 
 Here is an example for a record:
 


### PR DESCRIPTION
The docs for `custom` mention an external package as the definition source for the shrinkers. This does not seem to be the case any longer.

I propose to remove that sentence, as those who are interested in shrinkers can find them inside this package.