### PR TITLE
Unicode string test failure output

### DIFF
--- a/tests/src/Runner/String/Format.elm
+++ b/tests/src/Runner/String/Format.elm
@@ -114,8 +114,8 @@ hexInt int =
                                 15 ->
                                     "f"
 
-                                _ ->
-                                    String.fromInt (i |> remainderBy 16)
+                                decimalDigit ->
+                                    String.fromInt decimalDigit
                            )
         in
         zeroPad4 (hexIntInternal int)
@@ -135,11 +135,11 @@ escapeUnicodeChars s =
         |> List.map Char.toCode
         |> List.map
             (\c ->
-                if isAsciiChar c == False then
-                    "\\u{" ++ hexInt c ++ "}"
+                if isAsciiChar c then
+                    String.fromChar (Char.fromCode c)
 
                 else
-                    String.fromChar (Char.fromCode c)
+                    "\\u{" ++ hexInt c ++ "}"
             )
         |> String.join ""
 

--- a/tests/src/Runner/String/Format.elm
+++ b/tests/src/Runner/String/Format.elm
@@ -82,6 +82,13 @@ hexInt int =
 
     else
         let
+            zeroPad4 n =
+                if String.length n < 4 then
+                    zeroPad4 ("0" ++ n)
+
+                else
+                    n
+
             hexIntInternal i =
                 if i == 0 then
                     ""
@@ -111,7 +118,7 @@ hexInt int =
                                     String.fromInt (i |> remainderBy 16)
                            )
         in
-        hexIntInternal int
+        zeroPad4 (hexIntInternal int)
 
 
 escapeUnicodeChars s =

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -84,14 +84,18 @@ expectationTests =
                 \_ -> 141 |> Expect.equal 141
             ]
 
-       -- , describe "Expect.equal on unicode strings should show pretty output"
-       --     [ test "ascii" <|
-       --         \_ -> "😻🙀👻" |> Expect.equal "🙀👻😻🙈"
-       --     , test "ascii space vs nbsp" <|
-       --         \_ -> "asd qwe" |> Expect.equal "asd\u{00a0}qwe"
-       --     , test "ascii only" <|
-       --         \_ -> "asd qwe" |> Expect.equal "asd dwe"
-       --     ]
+        -- , describe "Expect.equal on unicode strings should show pretty output"
+        --     [ test "ascii" <|
+        --         \_ -> "😻🙀👻" |> Expect.equal "🙀👻😻🙈"
+        --     , test "ascii space vs nbsp" <|
+        --         \_ -> "asd qwe" |> Expect.equal "asd\u{00a0}qwe"
+        --     , test "ascii only" <|
+        --         \_ -> "asd qwe" |> Expect.equal "asd dwe"
+        --     , test "newline diff" <|
+        --         \_ -> "first\u{000a}second" |> Expect.equal "first\r\nsecond"
+        --     , test "long lines" <|
+        --         \_ -> "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in scelerisque arcu. Curabitur cursus efficitur turpis sed porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eu cursus ex. Proin accumsan quam quis dui semper finibus. Nunc vel nibh at tellus finibus rhoncus eu eget dolor. Sed eget neque ut lorem imperdiet fermentum. 😻 Morbi iaculis ante euismod, vulputate velit ut, varius velit. Nulla tempus dapibus mattis. In tempus, nisi a porta lobortis, nulla lacus iaculis quam, vel euismod magna risus at tortor. Integer porta urna odio. Nulla pellentesque dictum maximus. Donec auctor urna nec tortor imperdiet varius." |> Expect.equal "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in scelerisque arcu. Curabitur cursus efficitur turpis sed porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eu cursus ex. Proin accumsan quam quis dui semper finibus. Nunc vel nibh at tellus finibus rhoncus eu eget dolor. Sed eget neque ut lorem imperdiet fermentum. Morbi iaculis ante euismod, vulputate velit ut, varius velit. Nulla tempus dapibus mattis. In tempus, nisi a porta lobortis, nulla lacus iaculis quam, vel euismod magna risus at tortor. Integer porta urna odio. Nulla pellentesque dictum maximus. Donec auctor urna nec tortor imperdiet varius."
+        --     ]
         ]
 
 

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -83,6 +83,13 @@ expectationTests =
             , test "succeeds when equating two ints" <|
                 \_ -> 141 |> Expect.equal 141
             ]
+
+        -- , describe "Expect.equal on unicode strings should show pretty output"
+        --     [ test "ascii" <|
+        --         \_ -> "😻🙀👻" |> Expect.equal "🙀👻😻🙈"
+        --     , test "ascii space vs nbsp" <|
+        --         \_ -> "asd qwe" |> Expect.equal "asd\u{00a0}qwe"
+        --     ]
         ]
 
 

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -84,12 +84,14 @@ expectationTests =
                 \_ -> 141 |> Expect.equal 141
             ]
 
-        -- , describe "Expect.equal on unicode strings should show pretty output"
-        --     [ test "ascii" <|
-        --         \_ -> "😻🙀👻" |> Expect.equal "🙀👻😻🙈"
-        --     , test "ascii space vs nbsp" <|
-        --         \_ -> "asd qwe" |> Expect.equal "asd\u{00a0}qwe"
-        --     ]
+       -- , describe "Expect.equal on unicode strings should show pretty output"
+       --     [ test "ascii" <|
+       --         \_ -> "😻🙀👻" |> Expect.equal "🙀👻😻🙈"
+       --     , test "ascii space vs nbsp" <|
+       --         \_ -> "asd qwe" |> Expect.equal "asd\u{00a0}qwe"
+       --     , test "ascii only" <|
+       --         \_ -> "asd qwe" |> Expect.equal "asd dwe"
+       --     ]
         ]
 
 


### PR DESCRIPTION
This adds a unicode-escaped copy of any failing string that contains non-standard ascii characters. 

I'm not completely happy with the formatting, so if you have suggestions, please do tell. Otherwise, I think it's still much better than what we currently have. I'm comparing the escaped strings, not character by character, which is why we're getting diffs that cover part of an escape sequence. 

Solves https://github.com/elm-community/elm-test/issues/225 and #38.

```
↓ Expectations
↓ Expect.equal on unicode strings should show pretty output
✗ ascii
           ▼        ▼▼       ▼▼  
    "\u{1f63b}\u{1f640}\u{1f47b}" (same string but with unicode characters escaped)
     ▼   
    "😻🙀👻"
    |> Expect.equal
    "🙀👻😻🙈"
       ▲▲ 
    "\u{1f640}\u{1f47b}\u{1f63b}\u{1f648}" (same string but with unicode characters escaped)
           ▲▲▲▲▲▲▲▲▲▲        ▲▲      ▲ ▲  


↓ Expectations
↓ Expect.equal on unicode strings should show pretty output
✗ ascii space vs nbsp
        ▼    
    "asd qwe"
    ╵
    │ |> Expect.equal
    ╷
    "asd qwe"
        ▲    
    "asd\u{00a0}qwe" (same string but with unicode characters escaped)
        ▲▲▲▲▲▲    


↓ Expectations
↓ Expect.equal on unicode strings should show pretty output
✗ ascii only
         ▼   
    "asd qwe"
    ╵
    │ |> Expect.equal
    ╷
    "asd dwe"
         ▲   


↓ Expectations
↓ Expect.equal on unicode strings should show pretty output
✗ newline diff
                   
    "first\nsecond"
    ╵
    │ |> Expect.equal
    ╷
    "first\r\nsecond"
           ▲▲        


↓ Expectations
↓ Expect.equal on unicode strings should show pretty output
✗ long lines
                                                                                                                                                                                                                                                                                                                                                                                                            ▼▼▼▼▼▼▼▼▼▼                                                                                                                                                                                                                                                                                                     
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in scelerisque arcu. Curabitur cursus efficitur turpis sed porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eu cursus ex. Proin accumsan quam quis dui semper finibus. Nunc vel nibh at tellus finibus rhoncus eu eget dolor. Sed eget neque ut lorem imperdiet fermentum. \u{1f63b} Morbi iaculis ante euismod, vulputate velit ut, varius velit. Nulla tempus dapibus mattis. In tempus, nisi a porta lobortis, nulla lacus iaculis quam, vel euismod magna risus at tortor. Integer porta urna odio. Nulla pellentesque dictum maximus. Donec auctor urna nec tortor imperdiet varius." (same string but with unicode characters escaped)
                                                                                                                                                                                                                                                                                                                                                                                                            ▼▼                                                                                                                                                                                                                                                                                                     
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in scelerisque arcu. Curabitur cursus efficitur turpis sed porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eu cursus ex. Proin accumsan quam quis dui semper finibus. Nunc vel nibh at tellus finibus rhoncus eu eget dolor. Sed eget neque ut lorem imperdiet fermentum. 😻 Morbi iaculis ante euismod, vulputate velit ut, varius velit. Nulla tempus dapibus mattis. In tempus, nisi a porta lobortis, nulla lacus iaculis quam, vel euismod magna risus at tortor. Integer porta urna odio. Nulla pellentesque dictum maximus. Donec auctor urna nec tortor imperdiet varius."
    ╵
    │ |> Expect.equal
    ╷
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in scelerisque arcu. Curabitur cursus efficitur turpis sed porttitor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nunc eu cursus ex. Proin accumsan quam quis dui semper finibus. Nunc vel nibh at tellus finibus rhoncus eu eget dolor. Sed eget neque ut lorem imperdiet fermentum. Morbi iaculis ante euismod, vulputate velit ut, varius velit. Nulla tempus dapibus mattis. In tempus, nisi a porta lobortis, nulla lacus iaculis quam, vel euismod magna risus at tortor. Integer porta urna odio. Nulla pellentesque dictum maximus. Donec auctor urna nec tortor imperdiet varius."
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 


```