### PR TITLE
In test script, pull package version from elm.json

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -9,7 +9,7 @@ rm -Rf elm_home/0.19.0/package/elm-explorations/test
 mkdir -p elm_home
 mkdir -p elm_home/0.19.0/package
 
-PACKAGE_VERSION="1.2.0"
+PACKAGE_VERSION=`grep \"version ../elm.json | cut -d \" -f 4`
 mkdir -p elm_home/0.19.0/package/elm-explorations/test/${PACKAGE_VERSION}
 rsync -va ../ elm_home/0.19.0/package/elm-explorations/test/${PACKAGE_VERSION}/ --exclude tests --exclude elm-stuff --exclude .git --exclude node_modules
 


### PR DESCRIPTION
This prevents the tests from breaking whenever we bump the version.