### PR TITLE
Improve simplifiers

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -56,6 +56,7 @@ import MicroRandomExtra as Random
 import Random exposing (Generator)
 import RoseTree exposing (RoseTree(..))
 import Simplify exposing (Simplifier)
+import Simplify.Internal
 
 
 {-| The representation of fuzzers is opaque. Conceptually, a `Fuzzer a`
@@ -120,12 +121,8 @@ Here is an example for a custom union type, assuming there is already a `genName
 -}
 custom : Generator a -> Simplifier a -> Fuzzer a
 custom generator simplifier =
-    let
-        simplifyTree a =
-            Rose a (Lazy.lazy <| \_ -> Lazy.force <| Lazy.List.map simplifyTree (simplifier a))
-    in
     Ok <|
-        Random.map simplifyTree generator
+        Random.map (Simplify.Internal.simplifyTree simplifier) generator
 
 
 {-| A fuzzer for the unit value. Unit is a type with only one value, commonly

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1,6 +1,6 @@
 module Simplify exposing
     ( Simplifier, simplify
-    , noSimplify, unit, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
+    , simplest, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
     , maybe, result, lazylist, list, array, tuple, tuple3
     , keepIf, dropIf, merge, map, andMap
     , fromFunction, convert
@@ -32,7 +32,7 @@ fail and find a simpler input that also fails, to better illustrate the bug.
 
 ## Readymade Simplifiers
 
-@docs noSimplify, unit, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
+@docs simplest, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
 
 
 ## Simplifiers of data structures
@@ -196,20 +196,14 @@ simplify keepSimplifying (Simp simplifier) originalVal =
     helper (simplifier originalVal) originalVal
 
 
-{-| Perform no simplifying. Equivalent to the empty lazy list.
+{-| A simplifier that performs no simplifying. Whatever value it's given,
+it claims that it's the simplest. This allows you to opt-out of simplification.
 -}
-noSimplify : Simplifier a
-noSimplify =
+simplest : Simplifier a
+simplest =
     Simp <|
         \_ ->
             empty
-
-
-{-| Simplify the empty tuple. Equivalent to `noSimplify`.
--}
-unit : Simplifier ()
-unit =
-    noSimplify
 
 
 {-| Simplifier of bools.

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1,7 +1,7 @@
 module Simplify exposing
     ( Simplifier, simplify
     , simplest, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
-    , maybe, result, lazylist, list, array, tuple, tuple3
+    , maybe, result, list, array, tuple, tuple3
     , keepIf, dropIf, merge, map, andMap
     , fromFunction, convert
     )
@@ -37,7 +37,7 @@ fail and find a simpler input that also fails, to better illustrate the bug.
 
 ## Simplifiers of data structures
 
-@docs maybe, result, lazylist, list, array, tuple, tuple3
+@docs maybe, result, list, array, tuple, tuple3
 
 
 ## Functions on Simplifiers

--- a/src/Simplify/Internal.elm
+++ b/src/Simplify/Internal.elm
@@ -1,0 +1,18 @@
+module Simplify.Internal exposing (Simplifier(..), simplifyTree)
+
+import Lazy
+import Lazy.List exposing (LazyList)
+import RoseTree exposing (RoseTree(..))
+
+
+type Simplifier a
+    = Simp (a -> LazyList a)
+
+
+simplifyTree : Simplifier a -> a -> RoseTree a
+simplifyTree (Simp simplifier) root =
+    let
+        branches _ =
+            Lazy.List.map (simplifyTree (Simp simplifier)) (simplifier root) |> Lazy.force
+    in
+    Rose root (Lazy.lazy branches)

--- a/tests/src/Helpers.elm
+++ b/tests/src/Helpers.elm
@@ -151,7 +151,7 @@ testSimplifying =
 -}
 randomSeedFuzzer : Fuzzer Random.Seed
 randomSeedFuzzer =
-    Fuzz.custom (Random.int 0 0xFFFFFFFF) Simplify.noSimplify |> Fuzz.map Random.initialSeed
+    Fuzz.custom (Random.int 0 0xFFFFFFFF) Simplify.simplest |> Fuzz.map Random.initialSeed
 
 
 same : Expectation -> Expectation -> Expectation

--- a/tests/src/SimplifyTests.elm
+++ b/tests/src/SimplifyTests.elm
@@ -11,7 +11,7 @@ all =
         [ describe "list" <|
             let
                 simplify =
-                    Simplify.simplify (always True) (Simplify.list Simplify.unit)
+                    Simplify.simplify (always True) (Simplify.list Simplify.simplest)
             in
             [ test "empty list does not simplify" <|
                 \() ->

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -108,19 +108,20 @@ expectationTests =
 regressions : Test
 regressions =
     describe "regression tests"
-        [ fuzz (intRange 1 32) "for #39" <|
+        [ fuzz (intRange 1 32) "for elm-community/elm-test #39" <|
             \positiveInt ->
                 positiveInt
                     |> Expect.greaterThan 0
-        , test "for #127" <|
+        , test "for elm-community/elm-test #127" <|
             {- If fuzz tests actually run 100 times, then asserting that no number
                in 1..8 equals 5 fails with 0.999998 probability. If they only run
                once, or stop after a duplicate due to #127, then it's much more
                likely (but not guaranteed) that the 5 won't turn up. See #128.
+               (Issue numbers refer to elm-community/elm-test.)
             -}
             \() ->
                 fuzz
-                    (custom (Random.int 1 8) Simplify.noSimplify)
+                    (custom (Random.int 1 8) Simplify.simplest)
                     "fuzz tests run 100 times"
                     (Expect.notEqual 5)
                     |> expectTestToFail


### PR DESCRIPTION
Do not expose lazy lists at all to the user. Do various other cleanup and polish tasks.

TODO:
- [x] Make Simplifiers an opaque type
- [x] Update documentation
- [x] Create/expose `Simplify.fromFunction : (a -> List a) -> Simplifier a`
- [x] Rename `noSimplify` to `simplest`
- ~~Figure out why we have two exposed ways of running simplification, in `Test.Runner` and in `Simplify`. Likely remove one.~~
  - The former runs fuzzers, the latter runs simplifiers. Worthy of further discussion so punting from this PR.
- [x] Do no export `Simplify.lazyList` to fix #67

Tagging as major release blocker because there are lots of breaking changes. Ideally we would keep breaking changes off master until we're ready to release but that ship has already sailed.