### PR TITLE
 Rename tuple and tuple3 functions to pair and triple. 

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -1,7 +1,7 @@
 module Fuzz exposing
     ( int, intRange, float, floatRange, percentage, string, bool, maybe, result, list, array
     , Fuzzer, oneOf, constant, map, map2, map3, map4, map5, andMap, frequency
-    , replacemeForPair, replacemeForTriplet
+    , pair, triple
     , custom, char, unit, order, invalid
     )
 
@@ -31,7 +31,7 @@ reproduces a bug.
 
 Instead of using a tuple, consider using `fuzzN`.
 
-@docs replacemeForPair, replacemeForTriplet
+@docs pair, triple
 
 
 ## Uncommon Fuzzers
@@ -466,17 +466,17 @@ array fuzzer =
     map Array.fromList (list fuzzer)
 
 
-{-| Turn a replacemeForPair of fuzzers into a fuzzer of replacemeForPairs.
+{-| Turn a pair of fuzzers into a fuzzer of pairs.
 -}
-replacemeForPair : ( Fuzzer a, Fuzzer b ) -> Fuzzer ( a, b )
-replacemeForPair ( fuzzerA, fuzzerB ) =
+pair : ( Fuzzer a, Fuzzer b ) -> Fuzzer ( a, b )
+pair ( fuzzerA, fuzzerB ) =
     map2 (\a b -> ( a, b )) fuzzerA fuzzerB
 
 
-{-| Turn a replacemeForTriplet of fuzzers into a fuzzer of replacemeForTriplets.
+{-| Turn a triple of fuzzers into a fuzzer of triples.
 -}
-replacemeForTriplet : ( Fuzzer a, Fuzzer b, Fuzzer c ) -> Fuzzer ( a, b, c )
-replacemeForTriplet ( fuzzerA, fuzzerB, fuzzerC ) =
+triple : ( Fuzzer a, Fuzzer b, Fuzzer c ) -> Fuzzer ( a, b, c )
+triple ( fuzzerA, fuzzerB, fuzzerC ) =
     map3 (\a b c -> ( a, b, c )) fuzzerA fuzzerB fuzzerC
 
 

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -1,7 +1,7 @@
 module Fuzz exposing
     ( int, intRange, float, floatRange, percentage, string, bool, maybe, result, list, array
     , Fuzzer, oneOf, constant, map, map2, map3, map4, map5, andMap, frequency
-    , tuple, tuple3
+    , replacemeForPair, replacemeForTriplet
     , custom, char, unit, order, invalid
     )
 
@@ -31,7 +31,7 @@ reproduces a bug.
 
 Instead of using a tuple, consider using `fuzzN`.
 
-@docs tuple, tuple3
+@docs replacemeForPair, replacemeForTriplet
 
 
 ## Uncommon Fuzzers
@@ -466,17 +466,17 @@ array fuzzer =
     map Array.fromList (list fuzzer)
 
 
-{-| Turn a tuple of fuzzers into a fuzzer of tuples.
+{-| Turn a replacemeForPair of fuzzers into a fuzzer of replacemeForPairs.
 -}
-tuple : ( Fuzzer a, Fuzzer b ) -> Fuzzer ( a, b )
-tuple ( fuzzerA, fuzzerB ) =
+replacemeForPair : ( Fuzzer a, Fuzzer b ) -> Fuzzer ( a, b )
+replacemeForPair ( fuzzerA, fuzzerB ) =
     map2 (\a b -> ( a, b )) fuzzerA fuzzerB
 
 
-{-| Turn a 3-tuple of fuzzers into a fuzzer of 3-tuples.
+{-| Turn a replacemeForTriplet of fuzzers into a fuzzer of replacemeForTriplets.
 -}
-tuple3 : ( Fuzzer a, Fuzzer b, Fuzzer c ) -> Fuzzer ( a, b, c )
-tuple3 ( fuzzerA, fuzzerB, fuzzerC ) =
+replacemeForTriplet : ( Fuzzer a, Fuzzer b, Fuzzer c ) -> Fuzzer ( a, b, c )
+replacemeForTriplet ( fuzzerA, fuzzerB, fuzzerC ) =
     map3 (\a b c -> ( a, b, c )) fuzzerA fuzzerB fuzzerC
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1,7 +1,7 @@
 module Simplify exposing
     ( Simplifier, simplify
     , simplest, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
-    , maybe, result, list, array, replacemeForPair, replacemeForTriplet
+    , maybe, result, list, array, pair, triple
     , keepIf, dropIf, merge
     , fromFunction, convert
     )
@@ -37,7 +37,7 @@ fail and find a simpler input that also fails, to better illustrate the bug.
 
 ## Simplifiers of data structures
 
-@docs maybe, result, list, array, replacemeForPair, replacemeForTriplet
+@docs maybe, result, list, array, pair, triple
 
 
 ## Functions on Simplifiers
@@ -441,11 +441,11 @@ array simplifier =
     convert Lazy.List.toArray Lazy.List.fromArray (lazylist simplifier)
 
 
-{-| ReplacemeForPair simplifier constructor.
-Takes a replacemeForPair of simplifiers and returns a simplifier of replacemeForPairs.
+{-| Pair simplifier constructor.
+Takes a pair of simplifiers and returns a simplifier of pairs.
 -}
-replacemeForPair : ( Simplifier a, Simplifier b ) -> Simplifier ( a, b )
-replacemeForPair ( Simp simplifyA, Simp simplifyB ) =
+pair : ( Simplifier a, Simplifier b ) -> Simplifier ( a, b )
+pair ( Simp simplifyA, Simp simplifyB ) =
     Simp <|
         \( a, b ) ->
             append (Lazy.List.map (Tuple.pair a) (simplifyB b))
@@ -454,11 +454,11 @@ replacemeForPair ( Simp simplifyA, Simp simplifyB ) =
                 )
 
 
-{-| ReplacemeForTriplet simplifier constructor.
-Takes a replacemeForTriplet of simplifiers and returns a simplifier of replacemeForTriplets.
+{-| Triple simplifier constructor.
+Takes a triple of simplifiers and returns a simplifier of triples.
 -}
-replacemeForTriplet : ( Simplifier a, Simplifier b, Simplifier c ) -> Simplifier ( a, b, c )
-replacemeForTriplet ( Simp simplifyA, Simp simplifyB, Simp simplifyC ) =
+triple : ( Simplifier a, Simplifier b, Simplifier c ) -> Simplifier ( a, b, c )
+triple ( Simp simplifyA, Simp simplifyB, Simp simplifyC ) =
     Simp <|
         \( a, b, c ) ->
             append (Lazy.List.map (\c1 -> ( a, b, c1 )) (simplifyC c))

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1,7 +1,7 @@
 module Simplify exposing
     ( Simplifier, simplify
     , simplest, bool, int, float, string, order, atLeastInt, atLeastFloat, char, atLeastChar, character
-    , maybe, result, list, array, tuple, tuple3
+    , maybe, result, list, array, replacemeForPair, replacemeForTriplet
     , keepIf, dropIf, merge
     , fromFunction, convert
     )
@@ -37,7 +37,7 @@ fail and find a simpler input that also fails, to better illustrate the bug.
 
 ## Simplifiers of data structures
 
-@docs maybe, result, list, array, tuple, tuple3
+@docs maybe, result, list, array, replacemeForPair, replacemeForTriplet
 
 
 ## Functions on Simplifiers
@@ -441,11 +441,11 @@ array simplifier =
     convert Lazy.List.toArray Lazy.List.fromArray (lazylist simplifier)
 
 
-{-| 2-Tuple simplifier constructor.
-Takes a tuple of simplifiers and returns a simplifier of tuples.
+{-| ReplacemeForPair simplifier constructor.
+Takes a replacemeForPair of simplifiers and returns a simplifier of replacemeForPairs.
 -}
-tuple : ( Simplifier a, Simplifier b ) -> Simplifier ( a, b )
-tuple ( Simp simplifyA, Simp simplifyB ) =
+replacemeForPair : ( Simplifier a, Simplifier b ) -> Simplifier ( a, b )
+replacemeForPair ( Simp simplifyA, Simp simplifyB ) =
     Simp <|
         \( a, b ) ->
             append (Lazy.List.map (Tuple.pair a) (simplifyB b))
@@ -454,11 +454,11 @@ tuple ( Simp simplifyA, Simp simplifyB ) =
                 )
 
 
-{-| 3-Tuple simplifier constructor.
-Takes a tuple of simplifiers and returns a simplifier of tuples.
+{-| ReplacemeForTriplet simplifier constructor.
+Takes a replacemeForTriplet of simplifiers and returns a simplifier of replacemeForTriplets.
 -}
-tuple3 : ( Simplifier a, Simplifier b, Simplifier c ) -> Simplifier ( a, b, c )
-tuple3 ( Simp simplifyA, Simp simplifyB, Simp simplifyC ) =
+replacemeForTriplet : ( Simplifier a, Simplifier b, Simplifier c ) -> Simplifier ( a, b, c )
+replacemeForTriplet ( Simp simplifyA, Simp simplifyB, Simp simplifyC ) =
     Simp <|
         \( a, b, c ) ->
             append (Lazy.List.map (\c1 -> ( a, b, c1 )) (simplifyC c))

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -285,16 +285,16 @@ type alias FuzzOptions =
 {-| Run a [`fuzz`](#fuzz) test with the given [`FuzzOptions`](#FuzzOptions).
 
 Note that there is no `fuzzWith2`, but you can always pass more fuzz values in
-using [`Fuzz.tuple`](Fuzz#tuple), [`Fuzz.tuple3`](Fuzz#tuple3),
+using [`Fuzz.replacemeForPair`](Fuzz#replacemeForPair), [`Fuzz.replacemeForTriplet`](Fuzz#replacemeForTriplet),
 for example like this:
 
     import Test exposing (fuzzWith)
-    import Fuzz exposing (tuple, list, int)
+    import Fuzz exposing (replacemeForPair, list, int)
     import Expect
 
 
     fuzzWith { runs = 4200 }
-        (tuple ( list int, int ))
+        (replacemeForPair ( list int, int ))
         "List.reverse never influences List.member" <|
             \(nums, target) ->
                 List.member target (List.reverse nums)
@@ -376,9 +376,9 @@ fuzz =
 
 {-| Run a [fuzz test](#fuzz) using two random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.tuple`](Fuzz#tuple).
+This is a convenience function that lets you skip calling [`Fuzz.replacemeForPair`](Fuzz#replacemeForPair).
 
-See [`fuzzWith`](#fuzzWith) for an example of writing this in tuple style.
+See [`fuzzWith`](#fuzzWith) for an example of writing this using tuples.
 
     import Test exposing (fuzz2)
     import Fuzz exposing (list, int)
@@ -399,14 +399,14 @@ fuzz2 :
 fuzz2 fuzzA fuzzB desc =
     let
         fuzzer =
-            Fuzz.tuple ( fuzzA, fuzzB )
+            Fuzz.replacemeForPair ( fuzzA, fuzzB )
     in
     (\f ( a, b ) -> f a b) >> fuzz fuzzer desc
 
 
 {-| Run a [fuzz test](#fuzz) using three random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.tuple3`](Fuzz#tuple3).
+This is a convenience function that lets you skip calling [`Fuzz.replacemeForTriplet`](Fuzz#replacemeForTriplet).
 
 -}
 fuzz3 :
@@ -419,7 +419,7 @@ fuzz3 :
 fuzz3 fuzzA fuzzB fuzzC desc =
     let
         fuzzer =
-            Fuzz.tuple3 ( fuzzA, fuzzB, fuzzC )
+            Fuzz.replacemeForTriplet ( fuzzA, fuzzB, fuzzC )
     in
     uncurry3 >> fuzz fuzzer desc
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -285,16 +285,16 @@ type alias FuzzOptions =
 {-| Run a [`fuzz`](#fuzz) test with the given [`FuzzOptions`](#FuzzOptions).
 
 Note that there is no `fuzzWith2`, but you can always pass more fuzz values in
-using [`Fuzz.replacemeForPair`](Fuzz#replacemeForPair), [`Fuzz.replacemeForTriplet`](Fuzz#replacemeForTriplet),
+using [`Fuzz.pair`](Fuzz#pair), [`Fuzz.triple`](Fuzz#triple),
 for example like this:
 
     import Test exposing (fuzzWith)
-    import Fuzz exposing (replacemeForPair, list, int)
+    import Fuzz exposing (pair, list, int)
     import Expect
 
 
     fuzzWith { runs = 4200 }
-        (replacemeForPair ( list int, int ))
+        (pair ( list int, int ))
         "List.reverse never influences List.member" <|
             \(nums, target) ->
                 List.member target (List.reverse nums)
@@ -376,7 +376,7 @@ fuzz =
 
 {-| Run a [fuzz test](#fuzz) using two random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.replacemeForPair`](Fuzz#replacemeForPair).
+This is a convenience function that lets you skip calling [`Fuzz.pair`](Fuzz#pair).
 
 See [`fuzzWith`](#fuzzWith) for an example of writing this using tuples.
 
@@ -399,14 +399,14 @@ fuzz2 :
 fuzz2 fuzzA fuzzB desc =
     let
         fuzzer =
-            Fuzz.replacemeForPair ( fuzzA, fuzzB )
+            Fuzz.pair ( fuzzA, fuzzB )
     in
     (\f ( a, b ) -> f a b) >> fuzz fuzzer desc
 
 
 {-| Run a [fuzz test](#fuzz) using three random inputs.
 
-This is a convenience function that lets you skip calling [`Fuzz.replacemeForTriplet`](Fuzz#replacemeForTriplet).
+This is a convenience function that lets you skip calling [`Fuzz.triple`](Fuzz#triple).
 
 -}
 fuzz3 :
@@ -419,7 +419,7 @@ fuzz3 :
 fuzz3 fuzzA fuzzB fuzzC desc =
     let
         fuzzer =
-            Fuzz.replacemeForTriplet ( fuzzA, fuzzB, fuzzC )
+            Fuzz.triple ( fuzzA, fuzzB, fuzzC )
     in
     uncurry3 >> fuzz fuzzer desc
 

--- a/tests/src/FloatWithinTests.elm
+++ b/tests/src/FloatWithinTests.elm
@@ -129,7 +129,7 @@ floatWithinTests =
                             a |> Expect.notWithin (Absolute (abs epsilon)) b
                     in
                     different withinTest notWithinTest
-            , fuzz2 (replacemeForPair ( float, float )) (replacemeForPair ( float, float )) "within and notWithin should never agree on absolute or relative tolerance" <|
+            , fuzz2 (pair ( float, float )) (pair ( float, float )) "within and notWithin should never agree on absolute or relative tolerance" <|
                 \( absoluteEpsilon, relativeEpsilon ) ( a, b ) ->
                     let
                         withinTest =

--- a/tests/src/FloatWithinTests.elm
+++ b/tests/src/FloatWithinTests.elm
@@ -129,7 +129,7 @@ floatWithinTests =
                             a |> Expect.notWithin (Absolute (abs epsilon)) b
                     in
                     different withinTest notWithinTest
-            , fuzz2 (tuple ( float, float )) (tuple ( float, float )) "within and notWithin should never agree on absolute or relative tolerance" <|
+            , fuzz2 (replacemeForPair ( float, float )) (replacemeForPair ( float, float )) "within and notWithin should never agree on absolute or relative tolerance" <|
                 \( absoluteEpsilon, relativeEpsilon ) ( a, b ) ->
                     let
                         withinTest =

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -17,7 +17,7 @@ die =
 fuzzerTests : Test
 fuzzerTests =
     describe "Fuzzer methods that use Debug.crash don't call it"
-        [ describe "FuzzN (uses use replacemeForPair or replacmeForTriplet) testing string length properties"
+        [ describe "FuzzN (uses use pair or replacmeForTriplet) testing string length properties"
             [ fuzz2 string string "fuzz2" <|
                 \a b ->
                     testStringLengthIsPreserved [ a, b ]
@@ -42,19 +42,19 @@ fuzzerTests =
                             Random.step gen seed
 
                         aFuzzer =
-                            replacemeForTriplet
-                                ( replacemeForPair ( list int, array float )
-                                , replacemeForPair
+                            triple
+                                ( pair ( list int, array float )
+                                , pair
                                     ( maybe bool
                                     , result unit char
                                     )
-                                , replacemeForPair
-                                    ( replacemeForTriplet
+                                , pair
+                                    ( triple
                                         ( percentage
                                         , map2 (+) int int
                                         , frequency [ ( 1, constant True ), ( 3, constant False ) ]
                                         )
-                                    , replacemeForTriplet ( intRange 0 100, floatRange -51 pi, map abs int )
+                                    , triple ( intRange 0 100, floatRange -51 pi, map abs int )
                                     )
                                 )
                                 |> Test.Runner.fuzz

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -17,7 +17,7 @@ die =
 fuzzerTests : Test
 fuzzerTests =
     describe "Fuzzer methods that use Debug.crash don't call it"
-        [ describe "FuzzN (uses use pair or replacmeForTriplet) testing string length properties"
+        [ describe "FuzzN (uses use pair or triple) testing string length properties"
             [ fuzz2 string string "fuzz2" <|
                 \a b ->
                     testStringLengthIsPreserved [ a, b ]

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -17,7 +17,7 @@ die =
 fuzzerTests : Test
 fuzzerTests =
     describe "Fuzzer methods that use Debug.crash don't call it"
-        [ describe "FuzzN (uses tupleN) testing string length properties"
+        [ describe "FuzzN (uses use replacemeForPair or replacmeForTriplet) testing string length properties"
             [ fuzz2 string string "fuzz2" <|
                 \a b ->
                     testStringLengthIsPreserved [ a, b ]
@@ -42,19 +42,19 @@ fuzzerTests =
                             Random.step gen seed
 
                         aFuzzer =
-                            tuple3
-                                ( tuple ( list int, array float )
-                                , tuple
+                            replacemeForTriplet
+                                ( replacemeForPair ( list int, array float )
+                                , replacemeForPair
                                     ( maybe bool
                                     , result unit char
                                     )
-                                , tuple
-                                    ( tuple3
+                                , replacemeForPair
+                                    ( replacemeForTriplet
                                         ( percentage
                                         , map2 (+) int int
                                         , frequency [ ( 1, constant True ), ( 3, constant False ) ]
                                         )
-                                    , tuple3 ( intRange 0 100, floatRange -51 pi, map abs int )
+                                    , replacemeForTriplet ( intRange 0 100, floatRange -51 pi, map abs int )
                                     )
                                 )
                                 |> Test.Runner.fuzz

--- a/tests/src/Runner/String.elm
+++ b/tests/src/Runner/String.elm
@@ -105,8 +105,7 @@ indentLines str =
         |> String.join "\n"
 
 
-{-| Run a test and return a tuple of the output message and the number of
-tests that failed.
+{-| Run a test and return a Summary.
 
 Fuzz tests use a default run count of 100, and a fixed initial seed.
 
@@ -116,8 +115,7 @@ run =
     runWithOptions defaultRuns defaultSeed
 
 
-{-| Run a test and return a tuple of the output message and the number of
-tests that failed.
+{-| Run a test and return a Summary.
 -}
 runWithOptions : Int -> Random.Seed -> Test -> Summary
 runWithOptions runs seed test =


### PR DESCRIPTION
See #48.

I have a slight preference for going with `triplet` over `triple`. This PR uses `triple` although it would be easy for me to change that if folk are keen.