### PR TITLE
Make Fuzz.string generate unicode strings.

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -321,22 +321,19 @@ Shorter strings are more common, especially the empty string.
 string : Fuzzer String
 string =
     let
-        unicodeGenerator : Generator String
+        ( firstFreq, restFreqs ) =
+            unicodeCharGeneratorFrequencies
+
+        lengthGenerator =
+            Random.frequency
+                ( 3, Random.int 1 10 )
+                [ ( 0.2, Random.constant 0 )
+                , ( 1, Random.int 11 50 )
+                , ( 1, Random.int 50 1000 )
+                ]
+
         unicodeGenerator =
-            let
-                ( freq, rest ) =
-                    unicodeCharGeneratorFrequencies
-            in
-            frequencyList
-                (Random.frequency
-                    ( 3, Random.int 1 10 )
-                    [ ( 0.2, Random.constant 0 )
-                    , ( 1, Random.int 11 50 )
-                    , ( 1, Random.int 50 1000 )
-                    ]
-                )
-                freq
-                rest
+            frequencyList lengthGenerator firstFreq restFreqs
                 |> Random.map String.fromList
     in
     custom unicodeGenerator Simplify.string

--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -48,6 +48,7 @@ import Fuzz.Internal as Internal
         , Valid
         , ValidFuzzer
         , combineValid
+        , frequencyList
         , invalidReason
         )
 import Lazy
@@ -280,12 +281,39 @@ asciiCharGenerator =
     Random.map Char.fromCode (Random.int 32 126)
 
 
-whitespaceCharGenerator : Generator Char
-whitespaceCharGenerator =
-    Random.sample [ ' ', '\t', '\n' ] |> Random.map (Maybe.withDefault ' ')
+unicodeCharGeneratorFrequencies : ( ( Float, Generator Char ), List ( Float, Generator Char ) )
+unicodeCharGeneratorFrequencies =
+    let
+        ascii =
+            asciiCharGenerator
+
+        whitespace =
+            Random.sample [ ' ', '\t', '\n' ] |> Random.map (Maybe.withDefault ' ')
+
+        tilde =
+            '̃'
+
+        circumflex =
+            '̂'
+
+        diaeresis =
+            '̈'
+
+        combiningDiacriticalMarks =
+            Random.sample [ circumflex, tilde, diaeresis ] |> Random.map (Maybe.withDefault circumflex)
+
+        emoji =
+            Random.sample [ '🌈', '❤', '🔥' ] |> Random.map (Maybe.withDefault '❤')
+    in
+    ( ( 4, ascii )
+    , [ ( 1, whitespace )
+      , ( 1, combiningDiacriticalMarks )
+      , ( 1, emoji )
+      ]
+    )
 
 
-{-| Generates random printable ASCII strings of up to 1000 characters.
+{-| Generates random printable unicode strings of up to 1000 characters.
 
 Shorter strings are more common, especially the empty string.
 
@@ -293,28 +321,25 @@ Shorter strings are more common, especially the empty string.
 string : Fuzzer String
 string =
     let
-        asciiGenerator : Generator String
-        asciiGenerator =
-            Random.frequency
-                ( 3, Random.int 1 10 )
-                [ ( 0.2, Random.constant 0 )
-                , ( 1, Random.int 11 50 )
-                , ( 1, Random.int 50 1000 )
-                ]
-                |> Random.andThen (Random.lengthString asciiCharGenerator)
-
-        whitespaceGenerator : Generator String
-        whitespaceGenerator =
-            Random.int 1 10
-                |> Random.andThen (Random.lengthString whitespaceCharGenerator)
+        unicodeGenerator : Generator String
+        unicodeGenerator =
+            let
+                ( freq, rest ) =
+                    unicodeCharGeneratorFrequencies
+            in
+            frequencyList
+                (Random.frequency
+                    ( 3, Random.int 1 10 )
+                    [ ( 0.2, Random.constant 0 )
+                    , ( 1, Random.int 11 50 )
+                    , ( 1, Random.int 50 1000 )
+                    ]
+                )
+                freq
+                rest
+                |> Random.map String.fromList
     in
-    custom
-        (Random.frequency
-            ( 9, asciiGenerator )
-            [ ( 1, whitespaceGenerator )
-            ]
-        )
-        Simplify.string
+    custom unicodeGenerator Simplify.string
 
 
 {-| Given a fuzzer of a type, create a fuzzer of a maybe for that type.

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -319,11 +319,11 @@ unicodeStringFuzzerTests =
                     fuzz string "generates long strings with a single character" <|
                         \str ->
                             let
-                                countSequentialUniquesAtStart s =
+                                countSequentialEqualCharsAtStartOfString s =
                                     case s of
                                         a :: b :: cs ->
                                             if a == b then
-                                                1 + countSequentialUniquesAtStart (b :: cs)
+                                                1 + countSequentialEqualCharsAtStartOfString (b :: cs)
 
                                             else
                                                 0
@@ -331,7 +331,12 @@ unicodeStringFuzzerTests =
                                         _ ->
                                             0
                             in
-                            str |> String.toList |> countSequentialUniquesAtStart |> (\x -> x < 7) |> Expect.equal True
+                            str
+                                |> String.toList
+                                |> countSequentialEqualCharsAtStartOfString
+                                |> (\x -> x > 10)
+                                |> -- expecting this test to pass at least once, but we don't have an expectToPassAtLeastOnce function, so instead this inner expectation is reversed and we use expectToFail
+                                   Expect.equal False
         , test "the String.reverse bug that prevented us from releasing unicode string fuzzers in August 2017 is now fixed" <|
             -- if characters that span more than one utf-16 character work, this version of the unicode string fuzzer is good to go
             \() -> "🔥" |> String.reverse |> Expect.equal "🔥"

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -293,26 +293,41 @@ whitespace =
 unicodeStringFuzzerTests : Test
 unicodeStringFuzzerTests =
     describe "unicode string fuzzer" <|
+        -- These tests are a bit hard to read. Sorry about that.
+        --
+        -- The tools we have at our disposal are:
+        -- - Forall (∀) in the form of normal fuzz tests
+        -- - Exists not (∃𝑥¬) in the form of expectTestToFail
+        --
+        -- so with these tools we made these statistical tests:
+        --
+        -- `exists (fuzzed string) such that ((fuzzed string) contains (specific string))` -- what we want to test
+        -- <=> (¬¬𝑥 <=> 𝑥) (since the only tool for Exists we have is Exists not, we negate the body to counter that negation)
+        -- `exists (fuzzed string) such that (not (not ((fuzzed string) contains (specific string))))` -- what we actually test here
+        -- where
+        -- `expectTestsToFail x` <=> `exists (fuzzed string) such that (not x)`
+        -- so what our fuzz tests should looks like is
+        -- `(not ((fuzzed string) contains (specific string)))`
         [ test "generates ascii" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates ascii" <|
-                        \str -> str |> String.contains "E" |> Expect.equal True
+                        \str -> str |> String.contains "E" |> Expect.equal False
         , test "generates whitespace" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates whitespace" <|
-                        \str -> str |> String.contains "\t" |> Expect.equal True
+                        \str -> str |> String.contains "\t" |> Expect.equal False
         , test "generates combining diacritical marks" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates combining diacritical marks" <|
-                        \str -> str |> String.contains "̃" |> Expect.equal True
+                        \str -> str |> String.contains "̃" |> Expect.equal False
         , test "generates emoji" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates emoji" <|
-                        \str -> str |> String.contains "🔥" |> Expect.equal True
+                        \str -> str |> String.contains "🔥" |> Expect.equal False
         , test "generates long strings with a single character" <|
             \() ->
                 expectTestToFail <|

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -332,6 +332,12 @@ unicodeStringFuzzerTests =
                                             0
                             in
                             str |> String.toList |> countSequentialUniquesAtStart |> (\x -> x < 7) |> Expect.equal True
-        , fuzz string "the String.reverse bug that prevented us from releasing unicode string fuzzers in August 2017 is now fixed" <|
-            \s -> s |> String.reverse |> String.reverse |> Expect.equal s
+        , test "the String.reverse bug that prevented us from releasing unicode string fuzzers in August 2017 is now fixed" <|
+            -- if characters that span more than one utf-16 character work, this version of the unicode string fuzzer is good to go
+            \() -> "🔥" |> String.reverse |> Expect.equal "🔥"
+
+        --, test "String.reverse implements unicode string reversing correctly" <|
+        --    -- String.reverse still doesn't properly implement unicode string reversing, so combining emojis like skin tones or families break
+        --    -- Here's a test that should pass, since these emoji families are supposed to be counted as single elements when reversing the string. When I'm writing this, I instead get a per-character string reversal, which renders as four emojis after each other "👦👦👩👩" (plus a bunch of non-printable characters in-between).
+        --    \() -> "👩‍👩‍👦‍👦" |> String.reverse |> Expect.equal "👩‍👩‍👦‍👦"
         ]

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -332,4 +332,6 @@ unicodeStringFuzzerTests =
                                             0
                             in
                             str |> String.toList |> countSequentialUniquesAtStart |> (\x -> x < 7) |> Expect.equal True
+        , fuzz string "the String.reverse bug that prevented us from releasing unicode string fuzzers in August 2017 is now fixed" <|
+            \s -> s |> String.reverse |> String.reverse |> Expect.equal s
         ]


### PR DESCRIPTION
Copy of https://github.com/elm-community/elm-test/pull/204. This PR was originally made for elm 0.18 back in August 2017. We delayed merging it since there was a bug with `String.reverse` where it didn't handle emojis or composite characters correctly. The bug has since been both fixed and published, so all 0.19 elm/core versions now reverse the strings we use in this fuzzer properly. There are still issues with the string reversal algorithm used in elm, but this new fuzzer doesn't generate strings that hit those cases. 