### PR TITLE
Fix handling of nested Html.lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version                                                                              | Notes                                                                                                                                                     |
 | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [**1.2.1**](https://github.com/elm-explorations/test/tree/1.2.1)                     | Fixes a crash in `Test.Html` when the HTML contains nested `Html.Lazy` nodes. [#78](https://github.com/elm-explorations/test/issues/78)
 | [**1.2.0**](https://github.com/elm-explorations/test/tree/1.2.0)                     | Add HTML tests. [#41](https://github.com/elm-explorations/test/pull/41)
 | [**1.0.0**](https://github.com/elm-explorations/test/tree/1.0.0)                     | Update for Elm 0.19. Remove `Fuzz.andThen`, `Fuzz.conditional`, and `Test.Runner.getFailure`. Fail on equating floats to encourage checks with tolerance. `Test.Runner.fuzz` now returns a `Result`. |
 | renamed from **elm-community/elm-test** (below) to **elm-explorations/test** (above) |                                                                                                                                                           |

--- a/src/Elm/Kernel/HtmlAsJson.js
+++ b/src/Elm/Kernel/HtmlAsJson.js
@@ -27,6 +27,8 @@ function forceThunks(vNode) {
     // This is a lazy node; evaluate it
     var args = vNode[virtualDomKernelConstants.thunk];
     vNode[virtualDomKernelConstants.node] = vNode[virtualDomKernelConstants.thunk].apply(args);
+    // And then recurse into the evaluated node
+    vNode[virtualDomKernelConstants.node] = forceThunks(vNode[virtualDomKernelConstants.node]);
   }
   if (typeof vNode !== 'undefined' && vNode.$ === virtualDomKernelConstants.nodeTypeTagger) {
     // This is an Html.map; recurse into the node it is wrapping

--- a/src/Elm/Kernel/HtmlAsJson.js
+++ b/src/Elm/Kernel/HtmlAsJson.js
@@ -20,17 +20,22 @@ var virtualDomKernelConstants =
 
 function forceThunks(vNode) {
   if (typeof vNode !== "undefined" && vNode.$ === "#2") {
-      vNode.b = forceThunks(vNode.b);
+    // This is a tuple (the kids : List (String, Html) field of a Keyed node); recurse into the right side of the tuple
+    vNode.b = forceThunks(vNode.b);
   }
   if (typeof vNode !== 'undefined' && vNode.$ === virtualDomKernelConstants.nodeTypeThunk && !vNode[virtualDomKernelConstants.node]) {
-      var args = vNode[virtualDomKernelConstants.thunk];
-      vNode[virtualDomKernelConstants.node] = vNode[virtualDomKernelConstants.thunk].apply(args);
+    // This is a lazy node; evaluate it
+    var args = vNode[virtualDomKernelConstants.thunk];
+    vNode[virtualDomKernelConstants.node] = vNode[virtualDomKernelConstants.thunk].apply(args);
   }
   if (typeof vNode !== 'undefined' && vNode.$ === virtualDomKernelConstants.nodeTypeTagger) {
-      vNode[virtualDomKernelConstants.node] = forceThunks(vNode[virtualDomKernelConstants.node]);
+    // This is an Html.map; recurse into the node it is wrapping
+    vNode[virtualDomKernelConstants.node] = forceThunks(vNode[virtualDomKernelConstants.node]);
   }
   if (typeof vNode !== 'undefined' && typeof vNode[virtualDomKernelConstants.kids] !== 'undefined') {
-      vNode[virtualDomKernelConstants.kids] = vNode[virtualDomKernelConstants.kids].map(forceThunks);
+    // This is something with children (either a node with kids : List Html, or keyed with kids : List (String, Html));
+    // recurse into the children
+    vNode[virtualDomKernelConstants.kids] = vNode[virtualDomKernelConstants.kids].map(forceThunks);
   }
   return vNode;
 }

--- a/tests/src/Test/Html/QueryTests.elm
+++ b/tests/src/Test/Html/QueryTests.elm
@@ -26,6 +26,18 @@ all =
                     ]
                     |> Query.fromHtml
                     |> Query.has [ text "first text" ]
+        , test "lazy nodes inside of lazy are instantiated" <|
+            -- From https://github.com/elm-explorations/test/issues/78
+            \() ->
+                Lazy.lazy
+                    (\() ->
+                        Html.div []
+                            [ Lazy.lazy (\() -> Html.text "first text") ()
+                            ]
+                    )
+                    ()
+                    |> Query.fromHtml
+                    |> Query.has [ text "first text" ]
         , describe "parsing attributes" <|
             let
                 divWithAttribute attr =

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -17,7 +17,6 @@ import Test.Html.Query.MarkdownTests
 import Test.Html.QueryTests
 import Test.Html.SelectorTests
 import Test.Runner
-import Test.Runner.Failure exposing (Reason(..))
 
 
 all : Test


### PR DESCRIPTION
Fixes https://github.com/elm-explorations/test/issues/78

The issues was actually that evaluated lazy nodes were never recursed into (it turned out to have nothing to do with Html.Keyed)

To fix the Travis-CI build, this also removes the node 4 and node 6 (and adds node 12) CI configs (node 6 was end-of-lifed in April 2019: https://github.com/nodejs/Release#release-schedule).