### PR TITLE
Correct math mistake

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -268,7 +268,7 @@ The number of times to run each fuzz test. (Default is 100.)
     import Expect
 
 
-    fuzzWith { runs = 350 } (list int) "List.length should always be positive" <|
+    fuzzWith { runs = 350 } (list int) "List.length should never be negative" <|
         -- This anonymous function will be run 350 times, each time with a
         -- randomly-generated fuzzList value. (It will always be a list of ints
         -- because of (list int) above.)

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -356,7 +356,7 @@ You may find them elsewhere called [property-based tests](http://blog.jessitron.
     import Expect
 
 
-    fuzz (list int) "List.length should always be positive" <|
+    fuzz (list int) "List.length should always be non-negative" <|
         -- This anonymous function will be run 100 times, each time with a
         -- randomly-generated fuzzList value.
         \fuzzList ->

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -356,7 +356,7 @@ You may find them elsewhere called [property-based tests](http://blog.jessitron.
     import Expect
 
 
-    fuzz (list int) "List.length should always be non-negative" <|
+    fuzz (list int) "List.length should never be negative" <|
         -- This anonymous function will be run 100 times, each time with a
         -- randomly-generated fuzzList value.
         \fuzzList ->


### PR DESCRIPTION
The most common convention in mathematics is that `0` has no sign. The numbers greater than or equal to `0` are generally described with the term "non-negative".