### PR TITLE
update compiler to 0.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "description": "tests for elm-test, so you can elm-test while you elm-test",
   "scripts": {
-    "test": "elm make --docs=documentation.json && (cd tests && ./test.sh) && elm-format --validate src tests/src benchmarks"
+    "test": "./tests/make.sh && (cd tests && ./test.sh) && elm-format --validate src tests/src benchmarks"
   },
   "author": "Richard Feldman",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "elm": "latest-0.19.0",
-    "elm-format": "latest-0.19.0"
+    "elm": "latest-0.19.1",
+    "elm-format": "latest-0.19.1"
   },
   "dependencies": {}
 }

--- a/tests/elm.json
+++ b/tests/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.0",

--- a/tests/make.sh
+++ b/tests/make.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+sed -i 's/import Elm\.Kernel\.Debug/-- import Elm\.Kernel\.Debug/g' src/Test/Internal.elm
+
+elm make --docs=documentation.json
+exit_code=$?
+
+sed -i 's/-- import Elm\.Kernel\.Debug/import Elm\.Kernel\.Debug/g' src/Test/Internal.elm
+
+exit $exit_code

--- a/tests/make.sh
+++ b/tests/make.sh
@@ -2,11 +2,19 @@
 
 set -eu
 
-sed -i 's/import Elm\.Kernel\.Debug/-- import Elm\.Kernel\.Debug/g' src/Test/Internal.elm
+# Check that this script is run from top level directory
+if [[ $(git rev-parse --show-toplevel) != $(pwd) ]]; then
+  >&2 echo "Please run ./tests/make.sh from git root directory!"
+  exit 1
+fi
+
+FILE_WITH_IMPORT=src/Test/Internal.elm
+
+sed -i.bak 's/import Elm\.Kernel\.Debug/-- import Elm\.Kernel\.Debug/g' "$FILE_WITH_IMPORT"
 
 elm make --docs=documentation.json
 exit_code=$?
 
-sed -i 's/-- import Elm\.Kernel\.Debug/import Elm\.Kernel\.Debug/g' src/Test/Internal.elm
+mv "$FILE_WITH_IMPORT.bak" "$FILE_WITH_IMPORT"
 
 exit $exit_code

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4,14 +4,14 @@ set -ex
 
 rm -f elm.js
 rm -Rf elm-stuff
-rm -Rf elm_home/0.19.0/package/elm-explorations/test
+rm -Rf elm_home/0.19.1/packages/elm-explorations/test
 
 mkdir -p elm_home
-mkdir -p elm_home/0.19.0/package
+mkdir -p elm_home/0.19.1/packages
 
 PACKAGE_VERSION=`grep \"version ../elm.json | cut -d \" -f 4`
-mkdir -p elm_home/0.19.0/package/elm-explorations/test/${PACKAGE_VERSION}
-rsync -va ../ elm_home/0.19.0/package/elm-explorations/test/${PACKAGE_VERSION}/ --exclude tests --exclude elm-stuff --exclude .git --exclude node_modules
+mkdir -p elm_home/0.19.1/packages/elm-explorations/test/${PACKAGE_VERSION}
+rsync -va ../ elm_home/0.19.1/packages/elm-explorations/test/${PACKAGE_VERSION}/ --exclude tests --exclude elm-stuff --exclude .git --exclude node_modules
 
 if which runhaskell; then
     # this produces ./versions.dat, but that file
@@ -23,7 +23,7 @@ elif which stack; then
 else
     echo "$0: WARNING: Neither runhaskell or stack are available on your PATH, so I can't regenerate versions.dat"
 fi
-cp ./versions.dat elm_home/0.19.0/package/versions.dat
+cp ./versions.dat elm_home/0.19.1/packages/versions.dat
 
 export ELM_HOME="$(pwd)"/elm_home
 


### PR DESCRIPTION
Upgrading requires a hack to work around compiler error when importing non-local kernel models.

I am not sure it is worth it.