### PR TITLE
Prefix internal Test type variants so node-test-runner can find them

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -60,7 +60,7 @@ concat tests =
                     }
 
             Ok _ ->
-                Internal.Batch tests
+                Internal.ElmTestVariant__Batch tests
 
 
 {-| Apply a description to a list of tests.
@@ -121,7 +121,7 @@ describe untrimmedDesc tests =
                         }
 
                 else
-                    Internal.Labeled desc (Internal.Batch tests)
+                    Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__Batch tests)
 
 
 {-| Return a [`Test`](#Test) that evaluates a single
@@ -147,7 +147,7 @@ test untrimmedDesc thunk =
         Internal.blankDescriptionFailure
 
     else
-        Internal.Labeled desc (Internal.UnitTest (\() -> [ thunk () ]))
+        Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> [ thunk () ]))
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests
@@ -216,7 +216,7 @@ an `only` inside a `skip`, it will also get skipped.
 -}
 only : Test -> Test
 only =
-    Internal.Only
+    Internal.ElmTestVariant__Only
 
 
 {-| Returns a [`Test`](#Test) that gets skipped.
@@ -252,7 +252,7 @@ an `only` inside a `skip`, it will also get skipped.
 -}
 skip : Test -> Test
 skip =
-    Internal.Skipped
+    Internal.ElmTestVariant__Skipped
 
 
 {-| Options [`fuzzWith`](#fuzzWith) accepts. Currently there is only one but this
@@ -316,29 +316,29 @@ fuzzWith options fuzzer desc getTest =
 fuzzWithHelp : FuzzOptions -> Test -> Test
 fuzzWithHelp options aTest =
     case aTest of
-        Internal.UnitTest _ ->
+        Internal.ElmTestVariant__UnitTest _ ->
             aTest
 
-        Internal.FuzzTest run ->
-            Internal.FuzzTest (\seed _ -> run seed options.runs)
+        Internal.ElmTestVariant__FuzzTest run ->
+            Internal.ElmTestVariant__FuzzTest (\seed _ -> run seed options.runs)
 
-        Internal.Labeled label subTest ->
-            Internal.Labeled label (fuzzWithHelp options subTest)
+        Internal.ElmTestVariant__Labeled label subTest ->
+            Internal.ElmTestVariant__Labeled label (fuzzWithHelp options subTest)
 
-        Internal.Skipped subTest ->
+        Internal.ElmTestVariant__Skipped subTest ->
             -- It's important to treat skipped tests exactly the same as normal,
             -- until after seed distribution has completed.
             fuzzWithHelp options subTest
-                |> Internal.Only
+                |> Internal.ElmTestVariant__Only
 
-        Internal.Only subTest ->
+        Internal.ElmTestVariant__Only subTest ->
             fuzzWithHelp options subTest
-                |> Internal.Only
+                |> Internal.ElmTestVariant__Only
 
-        Internal.Batch tests ->
+        Internal.ElmTestVariant__Batch tests ->
             tests
                 |> List.map (fuzzWithHelp options)
-                |> Internal.Batch
+                |> Internal.ElmTestVariant__Batch
 
 
 {-| Take a function that produces a test, and calls it several (usually 100) times, using a randomly-generated input

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -32,14 +32,14 @@ fuzzTest fuzzer untrimmedDesc getExpectation =
 
             Ok validFuzzer ->
                 -- Preliminary checks passed; run the fuzz test
-                Labeled desc <| validatedFuzzTest validFuzzer getExpectation
+                ElmTestVariant__Labeled desc <| validatedFuzzTest validFuzzer getExpectation
 
 
 {-| Knowing that the fuzz test isn't obviously invalid, run the test and package up the results.
 -}
 validatedFuzzTest : ValidFuzzer a -> (a -> Expectation) -> Test
 validatedFuzzTest fuzzer getExpectation =
-    FuzzTest
+    ElmTestVariant__FuzzTest
         (\seed runs ->
             case runAllFuzzIterations fuzzer getExpectation seed runs |> Dict.toList of
                 [] ->

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -7,20 +7,24 @@ import Test.Expectation exposing (Expectation(..))
 import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
+{-| All variants of this type has the `ElmTestVariant__` prefix so that
+node-test-runner can recognize them in the compiled JavaScript. This lets us
+add more variants here without having to update the runner.
+-}
 type Test
-    = UnitTest (() -> List Expectation)
-    | FuzzTest (Random.Seed -> Int -> List Expectation)
-    | Labeled String Test
-    | Skipped Test
-    | Only Test
-    | Batch (List Test)
+    = ElmTestVariant__UnitTest (() -> List Expectation)
+    | ElmTestVariant__FuzzTest (Random.Seed -> Int -> List Expectation)
+    | ElmTestVariant__Labeled String Test
+    | ElmTestVariant__Skipped Test
+    | ElmTestVariant__Only Test
+    | ElmTestVariant__Batch (List Test)
 
 
 {-| Create a test that always fails for the given reason and description.
 -}
 failNow : { description : String, reason : Reason } -> Test
 failNow record =
-    UnitTest
+    ElmTestVariant__UnitTest
         (\() -> [ Test.Expectation.fail record ])
 
 
@@ -38,22 +42,22 @@ duplicatedName =
         names : Test -> List String
         names test =
             case test of
-                Labeled str _ ->
+                ElmTestVariant__Labeled str _ ->
                     [ str ]
 
-                Batch subtests ->
+                ElmTestVariant__Batch subtests ->
                     List.concatMap names subtests
 
-                UnitTest _ ->
+                ElmTestVariant__UnitTest _ ->
                     []
 
-                FuzzTest _ ->
+                ElmTestVariant__FuzzTest _ ->
                     []
 
-                Skipped subTest ->
+                ElmTestVariant__Skipped subTest ->
                     names subTest
 
-                Only subTest ->
+                ElmTestVariant__Only subTest ->
                     names subTest
 
         insertOrFail : String -> Result String (Set String) -> Result String (Set String)

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -10,6 +10,8 @@ import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 {-| All variants of this type has the `ElmTestVariant__` prefix so that
 node-test-runner can recognize them in the compiled JavaScript. This lets us
 add more variants here without having to update the runner.
+
+For more information, see https://github.com/elm-explorations/test/pull/153
 -}
 type Test
     = ElmTestVariant__UnitTest (() -> List Expectation)

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -11,7 +11,8 @@ import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 node-test-runner can recognize them in the compiled JavaScript. This lets us
 add more variants here without having to update the runner.
 
-For more information, see https://github.com/elm-explorations/test/pull/153
+For more information, see <https://github.com/elm-explorations/test/pull/153>
+
 -}
 type Test
     = ElmTestVariant__UnitTest (() -> List Expectation)

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -234,14 +234,14 @@ distributeSeeds =
 distributeSeedsHelp : Bool -> Int -> Random.Seed -> Test -> Distribution
 distributeSeedsHelp hashed runs seed test =
     case test of
-        Internal.UnitTest aRun ->
+        Internal.ElmTestVariant__UnitTest aRun ->
             { seed = seed
             , all = [ Runnable (Thunk (\_ -> aRun ())) ]
             , only = []
             , skipped = []
             }
 
-        Internal.FuzzTest aRun ->
+        Internal.ElmTestVariant__FuzzTest aRun ->
             let
                 ( firstSeed, nextSeed ) =
                     Random.step Random.independentSeed seed
@@ -252,7 +252,7 @@ distributeSeedsHelp hashed runs seed test =
             , skipped = []
             }
 
-        Internal.Labeled description subTest ->
+        Internal.ElmTestVariant__Labeled description subTest ->
             -- This fixes https://github.com/elm-community/elm-test/issues/192
             -- The first time we hit a Labeled, we want to use the hash of
             -- that label, along with the original seed, as our starting
@@ -305,7 +305,7 @@ distributeSeedsHelp hashed runs seed test =
                 , skipped = List.map (Labeled description) next.skipped
                 }
 
-        Internal.Skipped subTest ->
+        Internal.ElmTestVariant__Skipped subTest ->
             let
                 -- Go through the motions in order to obtain the seed, but then
                 -- move everything to skipped.
@@ -318,7 +318,7 @@ distributeSeedsHelp hashed runs seed test =
             , skipped = next.all
             }
 
-        Internal.Only subTest ->
+        Internal.ElmTestVariant__Only subTest ->
             let
                 next =
                     distributeSeedsHelp hashed runs seed subTest
@@ -326,7 +326,7 @@ distributeSeedsHelp hashed runs seed test =
             -- `only` all the things!
             { next | only = next.all }
 
-        Internal.Batch tests ->
+        Internal.ElmTestVariant__Batch tests ->
             List.foldl (batchDistribute hashed runs) (emptyDistribution seed) tests
 
 


### PR DESCRIPTION
**Explanation for why node-test-runner needs this:** https://github.com/rtfeldman/node-test-runner/pull/442#issuecomment-713526271

(Original discussion leading to this PR: https://github.com/rtfeldman/node-test-runner/pull/442#discussion_r495579878)