### PR TITLE
Proof of concept: allow Debug.log in fuzz tests

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -23,7 +23,7 @@ module Test exposing
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer)
 import Set
-import Test.Fuzz
+import Test.Fuzz exposing (Meta)
 import Test.Internal as Internal
 import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
@@ -301,7 +301,7 @@ for example like this:
                     |> Expect.equal (List.member target nums)
 
 -}
-fuzzWith : FuzzOptions -> Fuzzer a -> String -> (a -> Expectation) -> Test
+fuzzWith : FuzzOptions -> Fuzzer a -> String -> (Meta x -> a -> Expectation) -> Test
 fuzzWith options fuzzer desc getTest =
     if options.runs < 1 then
         Internal.failNow
@@ -368,7 +368,7 @@ You may find them elsewhere called [property-based tests](http://blog.jessitron.
 fuzz :
     Fuzzer a
     -> String
-    -> (a -> Expectation)
+    -> (Meta x -> a -> Expectation)
     -> Test
 fuzz =
     Test.Fuzz.fuzzTest
@@ -394,14 +394,14 @@ fuzz2 :
     Fuzzer a
     -> Fuzzer b
     -> String
-    -> (a -> b -> Expectation)
+    -> (Meta x -> a -> b -> Expectation)
     -> Test
 fuzz2 fuzzA fuzzB desc =
     let
         fuzzer =
             Fuzz.pair ( fuzzA, fuzzB )
     in
-    (\f ( a, b ) -> f a b) >> fuzz fuzzer desc
+    (\f meta ( a, b ) -> f meta a b) >> fuzz fuzzer desc
 
 
 {-| Run a [fuzz test](#fuzz) using three random inputs.
@@ -414,20 +414,11 @@ fuzz3 :
     -> Fuzzer b
     -> Fuzzer c
     -> String
-    -> (a -> b -> c -> Expectation)
+    -> (Meta x -> a -> b -> c -> Expectation)
     -> Test
 fuzz3 fuzzA fuzzB fuzzC desc =
     let
         fuzzer =
             Fuzz.triple ( fuzzA, fuzzB, fuzzC )
     in
-    uncurry3 >> fuzz fuzzer desc
-
-
-
--- INTERNAL HELPERS --
-
-
-uncurry3 : (a -> b -> c -> d) -> ( a, b, c ) -> d
-uncurry3 fn ( a, b, c ) =
-    fn a b c
+    (\f meta ( a, b, c ) -> f meta a b c) >> fuzz fuzzer desc

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -1,4 +1,4 @@
-module Test.Fuzz exposing (fuzzTest)
+module Test.Fuzz exposing (Meta, fuzzTest)
 
 import Dict exposing (Dict)
 import Fuzz exposing (Fuzzer)
@@ -11,9 +11,19 @@ import Test.Internal as Internal exposing (Test(..), blankDescriptionFailure, fa
 import Test.Runner.Failure exposing (InvalidReason(..), Reason(..))
 
 
+type alias Meta a =
+    { log : String -> a -> a }
+
+
+noopMeta : Meta a
+noopMeta =
+    { log = \_ a -> a
+    }
+
+
 {-| Reject always-failing tests because of bad names or invalid fuzzers.
 -}
-fuzzTest : Fuzzer a -> String -> (a -> Expectation) -> Test
+fuzzTest : Fuzzer a -> String -> (Meta x -> a -> Expectation) -> Test
 fuzzTest fuzzer untrimmedDesc getExpectation =
     let
         desc =
@@ -37,7 +47,7 @@ fuzzTest fuzzer untrimmedDesc getExpectation =
 
 {-| Knowing that the fuzz test isn't obviously invalid, run the test and package up the results.
 -}
-validatedFuzzTest : ValidFuzzer a -> (a -> Expectation) -> Test
+validatedFuzzTest : ValidFuzzer a -> (Meta x -> a -> Expectation) -> Test
 validatedFuzzTest fuzzer getExpectation =
     FuzzTest
         (\seed runs ->
@@ -56,33 +66,39 @@ type alias Failures =
 
 {-| Runs the specified number of fuzz tests and returns a dictionary of simplified failures.
 -}
-runAllFuzzIterations : ValidFuzzer a -> (a -> Expectation) -> Random.Seed -> Int -> Failures
+runAllFuzzIterations : ValidFuzzer a -> (Meta x -> a -> Expectation) -> Random.Seed -> Int -> Failures
 runAllFuzzIterations fuzzer getExpectation initialSeed totalRuns =
-    runOneFuzzIteration fuzzer getExpectation
-        |> foldUntil totalRuns ( Dict.empty, initialSeed )
-        -- throw away the random seed
-        |> Tuple.first
+    let
+        ( failures, _ ) =
+            runOneFuzzIteration totalRuns fuzzer getExpectation ( Dict.empty, initialSeed )
+    in
+    failures
 
 
 {-| Generate a fuzzed value, test it, and record the simplified test failure if any.
 -}
-runOneFuzzIteration : ValidFuzzer a -> (a -> Expectation) -> ( Failures, Random.Seed ) -> ( Failures, Random.Seed )
-runOneFuzzIteration fuzzer getExpectation ( failures, currentSeed ) =
-    let
-        ( rosetree, nextSeed ) =
-            Random.step fuzzer currentSeed
+runOneFuzzIteration : Int -> ValidFuzzer a -> (Meta x -> a -> Expectation) -> ( Failures, Random.Seed ) -> ( Failures, Random.Seed )
+runOneFuzzIteration runsLeft fuzzer getExpectation ( failures, currentSeed ) =
+    if Dict.isEmpty failures == False || runsLeft <= 1 then
+        -- short-circuit on failure so we don't spam 100 copies of all Debug.log messages if they all hit an error
+        ( failures, currentSeed )
 
-        newFailures =
-            case testGeneratedValue rosetree getExpectation of
-                Nothing ->
-                    -- test passed, nothing to change
-                    failures
+    else
+        let
+            ( rosetree, nextSeed ) =
+                Random.step fuzzer currentSeed
 
-                Just ( k, v ) ->
-                    -- record test failure
-                    Dict.insert k v failures
-    in
-    ( newFailures, nextSeed )
+            newFailures =
+                case testGeneratedValue rosetree getExpectation of
+                    Nothing ->
+                        -- test passed, nothing to change
+                        failures
+
+                    Just ( k, v ) ->
+                        -- record test failure
+                        Dict.insert k v failures
+        in
+        runOneFuzzIteration (runsLeft - 1) fuzzer getExpectation ( newFailures, nextSeed )
 
 
 {-| Run a function whose inputs are the same as its outputs a given number of times. Requires the initial state to pass
@@ -99,9 +115,9 @@ foldUntil remainingRuns initialState f =
 
 {-| Given a rosetree -- a root to test and branches of simplifications -- run the test and perform simplification if it fails.
 -}
-testGeneratedValue : RoseTree a -> (a -> Expectation) -> Maybe ( String, Expectation )
+testGeneratedValue : RoseTree a -> (Meta x -> a -> Expectation) -> Maybe ( String, Expectation )
 testGeneratedValue rosetree getExpectation =
-    case getExpectation (RoseTree.root rosetree) of
+    case getExpectation noopMeta (RoseTree.root rosetree) of
         Pass ->
             Nothing
 
@@ -111,11 +127,11 @@ testGeneratedValue rosetree getExpectation =
 
 {-| Knowing that the rosetree's root already failed, finds the key and value of the simplest failure.
 -}
-findSimplestFailure : RoseTree a -> (a -> Expectation) -> Expectation -> ( String, Expectation )
+findSimplestFailure : RoseTree a -> (Meta x -> a -> Expectation) -> Expectation -> ( String, Expectation )
 findSimplestFailure (Rose failingValue branches) getExpectation oldExpectation =
     case Lazy.List.headAndTail branches of
         Just ( (Rose possiblyFailingValue _) as firstChild, otherChildren ) ->
-            case getExpectation possiblyFailingValue of
+            case getExpectation noopMeta possiblyFailingValue of
                 -- recurse "horizontally" on other simplifications of the last known failing value
                 -- discard simplifications of the passing value (the _)
                 Pass ->
@@ -128,6 +144,10 @@ findSimplestFailure (Rose failingValue branches) getExpectation oldExpectation =
 
         -- base case: we cannot simplify any more
         Nothing ->
+            let
+                _ =
+                    getExpectation { log = Debug.log } failingValue
+            in
             ( Internal.toString failingValue, oldExpectation )
 
 

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,6 +1,7 @@
 module Test.Internal exposing (Test(..), blankDescriptionFailure, duplicatedName, failNow, toString)
 
-import Elm.Kernel.Debug
+-- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- import Elm.Kernel.Debug
+
 import Random exposing (Generator)
 import Set exposing (Set)
 import Test.Expectation exposing (Expectation(..))

--- a/tests/src/DebugLogTests.elm
+++ b/tests/src/DebugLogTests.elm
@@ -1,0 +1,26 @@
+module DebugLogTests exposing (all)
+
+import Expect exposing (FloatingPointTolerance(..))
+import Fuzz exposing (..)
+import Helpers exposing (..)
+import Test exposing (..)
+
+
+all : Test
+all =
+    describe "Meta Debug.log"
+        [ fuzz fuzzer "debug log for 1-arg fuzzer" <|
+            \meta a ->
+                meta.log (Debug.toString { desc = "fuzz1-meta-log", a = a }) <|
+                    (a |> Expect.notEqual 5)
+        , fuzz2 fuzzer fuzzer "debug log for 2-arg fuzzer" <|
+            \meta a b ->
+                meta.log (Debug.toString { desc = "fuzz2-meta-log", a = a, b = b }) <|
+                    (( a, b ) |> Expect.notEqual ( 2, 5 ))
+        , fuzz3 fuzzer fuzzer fuzzer "debug log for 3-arg fuzzer" <|
+            \meta a b c ->
+                meta.log (Debug.toString { desc = "fuzz3-meta-log", a = a, b = b, c = c }) <|
+                    (( a, b, c ) |> Expect.notEqual ( 2, 3, 5 ))
+        ]
+
+fuzzer = intRange 2 5

--- a/tests/src/FloatWithinTests.elm
+++ b/tests/src/FloatWithinTests.elm
@@ -11,14 +11,14 @@ floatWithinTests =
     describe "Expect.within"
         [ describe "use-cases"
             [ fuzz float "pythagorean identity" <|
-                \x ->
+                \_ x ->
                     sin x ^ 2 + cos x ^ 2 |> Expect.within (AbsoluteOrRelative 0.000001 0.00001) 1.0
             , test "floats known to not add exactly" <|
                 \_ -> 0.1 + 0.2 |> Expect.within (Absolute 0.000000001) 0.3
             , test "approximation of pi" <|
                 \_ -> 3.14 |> Expect.within (Absolute 0.01) pi
             , fuzz (floatRange 0.000001 100000) "relative tolerance of circle circumference using pi approximation" <|
-                \radius ->
+                \_ radius ->
                     (radius * pi)
                         |> Expect.within (Relative 0.001) (radius * 3.14)
             , test "approximation of pi is not considered too accurate" <|
@@ -30,14 +30,14 @@ floatWithinTests =
                 \() ->
                     expectTestToFail <|
                         fuzz (floatRange 0.000001 100000) "x" <|
-                            \radius ->
+                            \_ radius ->
                                 (radius * pi)
                                     |> Expect.within (Absolute 0.001) (radius * 3.14)
             , test "too high relative tolerance of circle circumference using pi approximation" <|
                 \() ->
                     expectTestToFail <|
                         fuzz (floatRange 0.000001 100000) "x" <|
-                            \radius ->
+                            \_ radius ->
                                 (radius * pi)
                                     |> Expect.within (Relative 0.0001) (radius * 3.14)
             ]
@@ -71,7 +71,7 @@ floatWithinTests =
             ]
         , describe "edge-cases"
             [ fuzz2 float float "self equality" <|
-                \epsilon value ->
+                \_ epsilon value ->
                     let
                         eps =
                             if epsilon /= 0 then
@@ -82,35 +82,35 @@ floatWithinTests =
                     in
                     value |> Expect.within (Relative (abs eps)) value
             , fuzz float "NaN inequality" <|
-                \epsilon ->
+                \_ epsilon ->
                     let
                         nan =
                             0.0 / 0.0
                     in
                     nan |> Expect.notWithin (Relative (abs epsilon)) nan
             , fuzz2 float float "NaN does not equal anything" <|
-                \epsilon a ->
+                \_ epsilon a ->
                     let
                         nan =
                             0.0 / 0.0
                     in
                     nan |> Expect.notWithin (Relative (abs epsilon)) a
             , fuzz float "Infinity equality" <|
-                \epsilon ->
+                \_ epsilon ->
                     let
                         infinity =
                             1.0 / 0.0
                     in
                     infinity |> Expect.within (Relative (abs epsilon)) infinity
             , fuzz float "Negative infinity equality" <|
-                \epsilon ->
+                \_ epsilon ->
                     let
                         negativeInfinity =
                             -1.0 / 0.0
                     in
                     negativeInfinity |> Expect.within (Relative (abs epsilon)) negativeInfinity
             , fuzz3 float float float "within and notWithin should never agree on relative tolerance" <|
-                \epsilon a b ->
+                \_ epsilon a b ->
                     let
                         withinTest =
                             a |> Expect.within (Relative (abs epsilon)) b
@@ -120,7 +120,7 @@ floatWithinTests =
                     in
                     different withinTest notWithinTest
             , fuzz3 float float float "within and notWithin should never agree on absolute tolerance" <|
-                \epsilon a b ->
+                \_ epsilon a b ->
                     let
                         withinTest =
                             a |> Expect.within (Absolute (abs epsilon)) b
@@ -130,7 +130,7 @@ floatWithinTests =
                     in
                     different withinTest notWithinTest
             , fuzz2 (pair ( float, float )) (pair ( float, float )) "within and notWithin should never agree on absolute or relative tolerance" <|
-                \( absoluteEpsilon, relativeEpsilon ) ( a, b ) ->
+                \_ ( absoluteEpsilon, relativeEpsilon ) ( a, b ) ->
                     let
                         withinTest =
                             a |> Expect.within (AbsoluteOrRelative (abs absoluteEpsilon) (abs relativeEpsilon)) b
@@ -140,24 +140,24 @@ floatWithinTests =
                     in
                     different withinTest notWithinTest
             , fuzz float "Zero equality" <|
-                \epsilon -> 0.0 |> Expect.within (Relative (abs epsilon)) 0.0
+                \_ epsilon -> 0.0 |> Expect.within (Relative (abs epsilon)) 0.0
             , fuzz3 float float float "within absolute commutativity" <|
-                \epsilon a b ->
+                \_ epsilon a b ->
                     same (Expect.within (Absolute (abs epsilon)) a b) (Expect.within (Absolute (abs epsilon)) b a)
             , fuzz3 float float float "notWithin absolute commutativity" <|
-                \epsilon a b ->
+                \_ epsilon a b ->
                     same (Expect.notWithin (Absolute (abs epsilon)) a b) (Expect.notWithin (Absolute (abs epsilon)) b a)
             , fuzz2 float float "within absolute reflexive" <|
-                \epsilon a ->
+                \_ epsilon a ->
                     Expect.within (Absolute (abs epsilon)) a a
             , fuzz3 float float float "within relative commutativity" <|
-                \epsilon a b ->
+                \_ epsilon a b ->
                     same (Expect.within (Relative (abs epsilon)) a b) (Expect.within (Relative (abs epsilon)) b a)
             , fuzz3 float float float "notWithin relative commutativity" <|
-                \epsilon a b ->
+                \_ epsilon a b ->
                     same (Expect.notWithin (Relative (abs epsilon)) a b) (Expect.notWithin (Relative (abs epsilon)) b a)
             , fuzz2 float float "within relative reflexive" <|
-                \epsilon a ->
+                \_ epsilon a ->
                     Expect.within (Relative (abs epsilon)) a a
             ]
         ]

--- a/tests/src/FuzzerTests.elm
+++ b/tests/src/FuzzerTests.elm
@@ -19,24 +19,24 @@ fuzzerTests =
     describe "Fuzzer methods that use Debug.crash don't call it"
         [ describe "FuzzN (uses use pair or triple) testing string length properties"
             [ fuzz2 string string "fuzz2" <|
-                \a b ->
+                \_ a b ->
                     testStringLengthIsPreserved [ a, b ]
             , fuzz3 string string string "fuzz3" <|
-                \a b c ->
+                \_ a b c ->
                     testStringLengthIsPreserved [ a, b, c ]
             ]
         , fuzz
             (intRange 1 6)
             "intRange"
-            (Expect.greaterThan 0)
+            (\_ -> Expect.greaterThan 0)
         , fuzz
             (frequency [ ( 1, intRange 1 6 ), ( 1, intRange 1 20 ) ])
             "Fuzz.frequency"
-            (Expect.greaterThan 0)
-        , fuzz (result string int) "Fuzz.result" <| \r -> Expect.pass
+            (\_ -> Expect.greaterThan 0)
+        , fuzz (result string int) "Fuzz.result" <| \_ r -> Expect.pass
         , describe "Whitebox testing using Fuzz.Internal"
             [ fuzz randomSeedFuzzer "the same value is generated with and without simplifying" <|
-                \seed ->
+                \_ seed ->
                     let
                         step gen =
                             Random.step gen seed
@@ -85,18 +85,18 @@ simplifyingTests =
     testSimplifying <|
         describe "tests that fail intentionally to test simplifying"
             [ fuzz2 int int "Every pair of ints has a zero" <|
-                \i j ->
+                \_ i j ->
                     (i == 0)
                         || (j == 0)
                         |> expectTrueAndExpectSimplifyResultToEqualString "(1,1)"
             , fuzz3 int int int "Every triple of ints has a zero" <|
-                \i j k ->
+                \_ i j k ->
                     (i == 0)
                         || (j == 0)
                         || (k == 0)
                         |> expectTrueAndExpectSimplifyResultToEqualString "(1,1,1)"
             , fuzz (list int) "All lists are sorted" <|
-                \aList ->
+                \_ aList ->
                     let
                         checkPair l =
                             case l of
@@ -134,7 +134,7 @@ manualFuzzerTests : Test
 manualFuzzerTests =
     describe "Test.Runner.{fuzz, simplify}"
         [ fuzz randomSeedFuzzer "Claim there are no even numbers" <|
-            \seed ->
+            \_ seed ->
                 let
                     -- fuzzer is guaranteed to produce an even number
                     fuzzer =
@@ -175,7 +175,7 @@ manualFuzzerTests =
                         , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
                         ]
         , fuzz randomSeedFuzzer "No strings contain the letter e" <|
-            \seed ->
+            \_ seed ->
                 let
                     -- fuzzer is guaranteed to produce a string with the letter e
                     fuzzer =
@@ -206,7 +206,7 @@ manualFuzzerTests =
                         , List.reverse >> List.head >> Expect.equal (Maybe.map Tuple.first pair)
                         ]
         , fuzz randomSeedFuzzer "List simplifier finds the smallest counter example" <|
-            \seed ->
+            \_ seed ->
                 let
                     fuzzer : Fuzzer (List Int)
                     fuzzer =
@@ -249,13 +249,13 @@ whitespaceTest : Test
 whitespaceTest =
     describe "fuzzing whitespace (taken from rtfeldman/elm-validate, which crashed when this first ran)"
         [ fuzz whitespace "whitespace characters are blank" <|
-            \str ->
+            \_ str ->
                 str
                     |> Validate.isBlank
                     |> Expect.equal True
                     >> Expect.onFail "Validate.isBlank should consider whitespace blank"
         , fuzz2 whitespace whitespace "non-whitespace characters mean it's not blank" <|
-            \prefix suffix ->
+            \_ prefix suffix ->
                 (prefix ++ "_" ++ suffix)
                     |> Validate.isBlank
                     |> Expect.equal False
@@ -312,27 +312,27 @@ unicodeStringFuzzerTests =
             \() ->
                 expectTestToFail <|
                     fuzz string "generates ascii" <|
-                        \str -> str |> String.contains "E" |> Expect.equal False
+                        \_ str -> str |> String.contains "E" |> Expect.equal False
         , test "generates whitespace" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates whitespace" <|
-                        \str -> str |> String.contains "\t" |> Expect.equal False
+                        \_ str -> str |> String.contains "\t" |> Expect.equal False
         , test "generates combining diacritical marks" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates combining diacritical marks" <|
-                        \str -> str |> String.contains "̃" |> Expect.equal False
+                        \_ str -> str |> String.contains "̃" |> Expect.equal False
         , test "generates emoji" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates emoji" <|
-                        \str -> str |> String.contains "🔥" |> Expect.equal False
+                        \_ str -> str |> String.contains "🔥" |> Expect.equal False
         , test "generates long strings with a single character" <|
             \() ->
                 expectTestToFail <|
                     fuzz string "generates long strings with a single character" <|
-                        \str ->
+                        \_ str ->
                             let
                                 countSequentialEqualCharsAtStartOfString s =
                                     case s of

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -25,7 +25,7 @@ fromTest =
     describe "TestRunner.fromTest"
         [ describe "test length"
             [ fuzz2 int int "only positive tests runs are valid" <|
-                \runs intSeed ->
+                \_ runs intSeed ->
                     case Test.Runner.fromTest runs (Random.initialSeed intSeed) passing of
                         Invalid str ->
                             if runs > 0 then

--- a/tests/src/SeedTests.elm
+++ b/tests/src/SeedTests.elm
@@ -35,14 +35,14 @@ exactly the string "Seed test".
 fuzzTest : Test
 fuzzTest =
     fuzz int "It receives the expected number" <|
-        \num ->
+        \_ num ->
             Expect.equal num expectedNum
 
 
 fuzzTestAfterOneDistributed : Test
 fuzzTestAfterOneDistributed =
     fuzz int "This should be different than expectedNum, because there is a fuzz test before it." <|
-        \num ->
+        \_ num ->
             Expect.equal num oneSeedAlreadyDistributed
 
 
@@ -52,7 +52,7 @@ tests =
         [ fuzzTest ]
     , describe "Seed test"
         [ fuzz int "It receives the expected number even though this text is different" <|
-            \num ->
+            \_ num ->
                 Expect.equal num expectedNum
         ]
     , describe "Seed test"
@@ -94,19 +94,19 @@ tests =
         ]
     , Test.concat
         [ fuzz int "top-level fuzz tests don't affect subsequent top-level fuzz tests, since they use their labels to get different seeds" <|
-            \num ->
+            \_ num ->
                 Expect.equal num -8
         , describe "Seed test"
             [ fuzzTest ]
         , describe "another top-level fuzz test"
             [ fuzz int "it still gets different values, due to computing the seed as a hash of the label, and these labels must be unique" <|
-                \num ->
+                \_ num ->
                     Expect.equal num -1079557009
             ]
         ]
     , describe "Fuzz tests with different outer describe texts get different seeds"
         [ fuzz int "It receives the expected number" <|
-            \num ->
+            \_ num ->
                 Expect.equal num 3556635839
         ]
     ]
@@ -141,7 +141,7 @@ noAutoFail =
         [ describe "Seed test"
             [ only <|
                 fuzz int "No Autofail here" <|
-                    \num ->
+                    \_ num ->
                         Expect.equal num expectedNum
             , test "This should never get run" <|
                 \() ->
@@ -152,14 +152,14 @@ noAutoFail =
       describe "Seed test"
         [ skip <|
             fuzz int "Skip test sanity check" <|
-                \_ ->
+                \_ _ ->
                     Expect.fail "Test.skip is broken! This should not have been run."
         , fuzzTestAfterOneDistributed
         ]
     , -- the previous test gets the same answer if Test.skip is removed
       describe "Seed test"
         [ fuzz int "Skip test sanity check" <|
-            \_ ->
+            \_ _ ->
                 Expect.pass
         , fuzzTestAfterOneDistributed
         ]
@@ -167,7 +167,7 @@ noAutoFail =
       describe "Seed test"
         [ only <|
             fuzz int "No Autofail here" <|
-                \num ->
+                \_ num ->
                     Expect.equal num expectedNum
         , test "this should never get run" <|
             \() ->

--- a/tests/src/Test/Html/QueryTests.elm
+++ b/tests/src/Test/Html/QueryTests.elm
@@ -581,7 +581,7 @@ testHas : Test
 testHas =
     describe "Query.has"
         [ fuzz (Fuzz.list Fuzz.string) "Passes for empty selector list" <|
-            \strings ->
+            \_ strings ->
                 Html.div [] (List.map Html.text strings)
                     |> Query.fromHtml
                     |> Query.has []

--- a/tests/src/Test/Html/SelectorTests.elm
+++ b/tests/src/Test/Html/SelectorTests.elm
@@ -46,7 +46,7 @@ textSelectors : Test
 textSelectors =
     describe "Selector.text"
         [ fuzz3 (list string) string (list string) "Finds one result" <|
-            \before str after ->
+            \_ before str after ->
                 let
                     textNodes =
                         [ before, [ str ], after ]
@@ -57,7 +57,7 @@ textSelectors =
                     |> Query.fromHtml
                     |> Query.has [ text str ]
         , fuzz3 (list string) (list string) (list string) "Finds multiple results" <|
-            \before strings after ->
+            \_ before strings after ->
                 let
                     textNodes =
                         [ before, strings, after ]

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing (all)
 
+import DebugLogTests
 import Expect exposing (FloatingPointTolerance(..))
 import FloatWithinTests exposing (floatWithinTests)
 import Fuzz exposing (..)
@@ -31,6 +32,7 @@ all =
         , SimplifyTests.all
         , RunnerTests.all
         , elmHtmlTests
+        , DebugLogTests.all
         ]
 
 
@@ -63,7 +65,7 @@ readmeExample =
                         |> String.reverse
                         |> Expect.equal "GFEDCBA"
             , fuzz string "restores the original string if you run it again" <|
-                \randomlyGeneratedString ->
+                \_ randomlyGeneratedString ->
                     randomlyGeneratedString
                         |> String.reverse
                         |> String.reverse
@@ -121,7 +123,7 @@ regressions : Test
 regressions =
     describe "regression tests"
         [ fuzz (intRange 1 32) "for elm-community/elm-test #39" <|
-            \positiveInt ->
+            \_ positiveInt ->
                 positiveInt
                     |> Expect.greaterThan 0
         , test "for elm-community/elm-test #127" <|
@@ -135,7 +137,7 @@ regressions =
                 fuzz
                     (custom (Random.int 1 8) Simplify.simplest)
                     "fuzz tests run 100 times"
-                    (Expect.notEqual 5)
+                    (\_ -> Expect.notEqual 5)
                     |> expectTestToFail
         ]
 
@@ -162,17 +164,17 @@ testTests =
         , describe "fuzz"
             [ test "fails with empty name" <|
                 \() ->
-                    fuzz Fuzz.bool "" expectPass
+                    fuzz Fuzz.bool "" (always expectPass)
                         |> expectTestToFail
             ]
         , describe "fuzzWith"
             [ test "fails with fewer than 1 run" <|
                 \() ->
-                    fuzzWith { runs = 0 } Fuzz.bool "nonpositive" expectPass
+                    fuzzWith { runs = 0 } Fuzz.bool "nonpositive" (always expectPass)
                         |> expectTestToFail
             , test "fails with empty name" <|
                 \() ->
-                    fuzzWith { runs = 1 } Fuzz.bool "" expectPass
+                    fuzzWith { runs = 1 } Fuzz.bool "" (always expectPass)
                         |> expectTestToFail
             ]
         , describe "Test.todo"


### PR DESCRIPTION
Proof of concept! Allow Debug.log to be used effectively in fuzz tests. 

Idea: pass an extra argument to all fuzzer test functions `{ log : String -> a -> a }`. This function is a no-op until we've found the simplest failing test case. The we run that simplest test case with a record that contains the real Debug.log function. Since it inherently works with side-effects, we can't easily capture and re-print stdout.

Fuzz tests:
```
all : Test
all =
    describe "Meta Debug.log"
        [ fuzz fuzzer "debug log for 1-arg fuzzer" <|
            \meta a ->
                meta.log (Debug.toString { desc = "fuzz1-meta-log", a = a }) <|
                    (a |> Expect.notEqual 5)
        , fuzz2 fuzzer fuzzer "debug log for 2-arg fuzzer" <|
            \meta a b ->
                meta.log (Debug.toString { desc = "fuzz2-meta-log", a = a, b = b }) <|
                    (( a, b ) |> Expect.notEqual ( 2, 5 ))
        , fuzz3 fuzzer fuzzer fuzzer "debug log for 3-arg fuzzer" <|
            \meta a b c ->
                meta.log (Debug.toString { desc = "fuzz3-meta-log", a = a, b = b, c = c }) <|
                    (( a, b, c ) |> Expect.notEqual ( 2, 3, 5 ))
        ]

fuzzer = intRange 2 5
```

Output:
```
{ a = 5, desc = "fuzz1-meta-log" }: Fail { description = "Expect.notEqual", given = Nothing, reason = Equality "5" "5" }
{ a = 2, b = 5, desc = "fuzz2-meta-log" }: Fail { description = "Expect.notEqual", given = Nothing, reason = Equality "(2,5)" "(2,5)" }
{ a = 2, b = 3, c = 5, desc = "fuzz3-meta-log" }: Fail { description = "Expect.notEqual", given = Nothing, reason = Equality "(2,3,5)" "(2,3,5)" }


↓ Meta Debug.log
✗ debug log for 1-arg fuzzer
Given 5

     
    5
    ╵
    │ |> Expect.notEqual
    ╷
    5
     


↓ Meta Debug.log
✗ debug log for 2-arg fuzzer
Given (2,5)

         
    (2,5)
    ╵
    │ |> Expect.notEqual
    ╷
    (2,5)
         


↓ Meta Debug.log
✗ debug log for 3-arg fuzzer
Given (2,3,5)

           
    (2,3,5)
    ╵
    │ |> Expect.notEqual
    ╷
    (2,3,5)
           


TEST RUN FAILED

Passed: 258
Failed: 3
```