### PR TITLE
Fix links, from elm-community to elm-explorations

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -342,7 +342,7 @@ fuzzWithHelp options aTest =
 
 
 {-| Take a function that produces a test, and calls it several (usually 100) times, using a randomly-generated input
-from a [`Fuzzer`](http://package.elm-lang.org/packages/elm-community/elm-test/latest/Fuzz) each time. This allows you to
+from a [`Fuzzer`](http://package.elm-lang.org/packages/elm-explorations/test/latest/Fuzz) each time. This allows you to
 test that a property that should always be true is indeed true under a wide variety of conditions. The function also
 takes a string describing the test.
 

--- a/tests/src/Runner/String/Format.elm
+++ b/tests/src/Runner/String/Format.elm
@@ -155,7 +155,7 @@ listDiffToString index description { expected, actual } originals =
         ( [], [] ) ->
             [ "Two lists were unequal previously, yet ended up equal later."
             , "This should never happen!"
-            , "Please report this bug to https://github.com/elm-community/elm-test/issues - and include these lists: "
+            , "Please report this bug to https://github.com/elm-explorations/test/issues - and include these lists: "
             , "\n"
             , Debug.toString originals.originalExpected
             , "\n"


### PR DESCRIPTION
Just ran across this issue looking at the docs at: https://package.elm-lang.org/packages/elm-explorations/test/latest/Test#fuzz

When I clicked the `Fuzzer` link, it took me to `elm-community/test` which isn't maintained (or compatible with 0.19).

Seraching through the codebase, I looked at every instance of `elm-community`, and most are links to the archived repo (and would break if we tried to link them to this repo now).

I did find another one, where it says to create an issue in the archived repo, which is not possible. Now it says to create an issue in this repo.