### PR TITLE
Aggregate multiple duplicate descriptions at the same level

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -53,9 +53,13 @@ concat tests =
 
     else
         case Internal.duplicatedName tests of
-            Err duped ->
+            Err dups ->
+                let
+                    dupDescription duped =
+                        "A test group contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
+                in
                 Internal.failNow
-                    { description = "A test group contains multiple tests named '" ++ duped ++ "'. Do some renaming so that tests have unique names."
+                    { description = String.join "\n" (List.map dupDescription <| Set.toList dups)
                     , reason = Invalid DuplicatedName
                     }
 
@@ -107,18 +111,24 @@ describe untrimmedDesc tests =
 
     else
         case Internal.duplicatedName tests of
-            Err duped ->
-                Internal.failNow
-                    { description = "The tests '" ++ desc ++ "' contain multiple tests named '" ++ duped ++ "'. Let's rename them so we know which is which."
-                    , reason = Invalid DuplicatedName
-                    }
+            Err dups ->
+                let
+                    dupDescription duped =
+                        "Contains multiple tests named '" ++ duped ++ "'. Let's rename them so we know which is which."
+                in
+                Internal.ElmTestVariant__Labeled desc <|
+                    Internal.failNow
+                        { description = String.join "\n" (List.map dupDescription <| Set.toList dups)
+                        , reason = Invalid DuplicatedName
+                        }
 
             Ok childrenNames ->
                 if Set.member desc childrenNames then
-                    Internal.failNow
-                        { description = "The test '" ++ desc ++ "' contains a child test of the same name. Let's rename them so we know which is which."
-                        , reason = Invalid DuplicatedName
-                        }
+                    Internal.ElmTestVariant__Labeled desc <|
+                        Internal.failNow
+                            { description = "The test '" ++ desc ++ "' contains a child test of the same name. Let's rename them so we know which is which."
+                            , reason = Invalid DuplicatedName
+                            }
 
                 else
                     Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__Batch tests)

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,5 +1,6 @@
 module Test.Internal exposing (Test(..), blankDescriptionFailure, duplicatedName, failNow, toString)
 
+import Elm.Kernel.Debug
 import Random exposing (Generator)
 import Set exposing (Set)
 import Test.Expectation exposing (Expectation(..))
@@ -83,4 +84,4 @@ duplicatedName tests =
 
 toString : a -> String
 toString =
-    Debug.toString
+    Elm.Kernel.Debug.toString

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -1,6 +1,5 @@
 module Test.Internal exposing (Test(..), blankDescriptionFailure, duplicatedName, failNow, toString)
 
-import Elm.Kernel.Debug
 import Random exposing (Generator)
 import Set exposing (Set)
 import Test.Expectation exposing (Expectation(..))
@@ -39,8 +38,8 @@ blankDescriptionFailure =
         }
 
 
-duplicatedName : List Test -> Result String (Set String)
-duplicatedName =
+duplicatedName : List Test -> Result (Set String) (Set String)
+duplicatedName tests =
     let
         names : Test -> List String
         names test =
@@ -63,21 +62,25 @@ duplicatedName =
                 ElmTestVariant__Only subTest ->
                     names subTest
 
-        insertOrFail : String -> Result String (Set String) -> Result String (Set String)
-        insertOrFail newName =
-            Result.andThen
-                (\oldNames ->
-                    if Set.member newName oldNames then
-                        Err newName
+        accumDuplicates : String -> ( Set String, Set String ) -> ( Set String, Set String )
+        accumDuplicates newName ( dups, uniques ) =
+            if Set.member newName uniques then
+                ( Set.insert newName dups, uniques )
 
-                    else
-                        Ok <| Set.insert newName oldNames
-                )
+            else
+                ( dups, Set.insert newName uniques )
+
+        ( dupsAccum, uniquesAccum ) =
+            List.concatMap names tests
+                |> List.foldl accumDuplicates ( Set.empty, Set.empty )
     in
-    List.concatMap names
-        >> List.foldl insertOrFail (Ok Set.empty)
+    if Set.isEmpty dupsAccum then
+        Ok uniquesAccum
+
+    else
+        Err dupsAccum
 
 
 toString : a -> String
 toString =
-    Elm.Kernel.Debug.toString
+    Debug.toString


### PR DESCRIPTION
Hi, following [suggestions that it would be nicer to have all duplicates at once](https://discourse.elm-lang.org/t/gathering-feedback-on-elm-test-rs-before-1-0-release/6851/6?u=mattpiz), I've come up with a possible implementation of this. Given the following tests:

```elm
concatDup : Test
concatDup =
    Test.concat
        [ Test.test "should pass" (\_ -> Expect.pass)
        , Test.test "should pass" (\_ -> Expect.pass)
        , Test.test "should fail" (\_ -> Expect.fail "force failed")
        , Test.test "should fail" (\_ -> Expect.fail "force failed")
        ]


suite : Test
suite =
    Test.describe "suite"
        [ Test.test "should pass" (\_ -> Expect.pass)
        , Test.test "should pass" (\_ -> Expect.pass)
        , Test.test "should fail" (\_ -> Expect.fail "force failed")
        , Test.test "should fail" (\_ -> Expect.fail "force failed")
        ]


anotherSuite : Test
anotherSuite =
    Test.describe "another suite"
        [ Test.test "another suite" (\_ -> Expect.pass)
        ]
```
Instead of getting the following elm-test output:
```
✗ Tests

    The test 'another suite' contains a child test of the same name. Let's rename them so we know which is which.


✗ Tests

    A test group contains multiple tests named 'should pass'. Do some renaming so that tests have unique names.


✗ Tests

    The tests 'suite' contain multiple tests named 'should pass'. Let's rename them so we know which is which.
```
We are getting the following one:
```
↓ Tests
✗ another suite

    The test 'another suite' contains a child test of the same name. Let's rename them so we know which is which.


✗ Tests

    A test group contains multiple tests named 'should fail'. Do some renaming so that tests have unique names.
    A test group contains multiple tests named 'should pass'. Do some renaming so that tests have unique names.


↓ Tests
✗ suite

    Contains multiple tests named 'should fail'. Let's rename them so we know which is which.
    Contains multiple tests named 'should pass'. Let's rename them so we know which is which.
```
You can notice that in the case of `concat` and `describe`, both "should fail" and "should pass" duplicates are reported. And in the case of `describe` and of duplicate child, the labels go one step further.

To gather all duplicates, I simply aggregate them inside a `Set` instead of failing fast with a `Result.andThen` in `fold`.

Side note, I had to remove the `Elm.Kernel.Debug` import to be able to compile, I'm not sure why.