### PR TITLE
Fix the code snippet in the document of Fuzz.custom

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -102,7 +102,7 @@ Here is an example for a custom union type, assuming there is already a `genName
     question =
         let
             generator =
-                Random.bool
+                uniform True [False]
                     |> Random.andThen
                         (\b ->
                             if b then


### PR DESCRIPTION
It uses `Random.bool`, however [Random of elm/random 1.0.0 ](https://package.elm-lang.org/packages/elm/random/1.0.0/Random) doesn't contain `bool`.

See also: https://github.com/elm-explorations/test/issues/164