### PR TITLE
Add missing `|> Query.fromHtml` to doc example of `Selector.containing`

### DIFF
--- a/src/Test/Html/Selector.elm
+++ b/src/Test/Html/Selector.elm
@@ -277,6 +277,7 @@ text somewhere in their descendants.
                 [ Html.button [ onClick NopeMsg ] [ Html.text "not me" ]
                 , Html.button [ onClick ClickedMsg ] [ Html.text "click me" ]
                 ]
+                |> Query.fromHtml
                 |> Query.find
                     [ tag "button"
                     , containing [ text "click me" ]


### PR DESCRIPTION
This is just a minimal change where the documentation code example was missing `Query.fromHtml` and did not work because of that.

See https://package.elm-lang.org/packages/elm-explorations/test/1.2.2/Test-Html-Selector#containing