### PR TITLE
Stop crashing in Fuzz.examples

### DIFF
--- a/src/Fuzz.elm
+++ b/src/Fuzz.elm
@@ -1652,6 +1652,8 @@ Useful in REPL:
 
 Uses seed 0.
 
+Will return an empty list in case of rejection.
+
 -}
 examples : Int -> Fuzzer a -> List a
 examples n fuzzer =
@@ -1664,7 +1666,7 @@ examples n fuzzer =
             value
 
         Rejected { reason } ->
-            Internal.crash ("Couldn't generate: " ++ reason)
+            []
 
 
 {-| (Avoid this function if you can! It is only provided as an escape hatch.)


### PR DESCRIPTION
This was an oversight: crashing is fine inside REPL but there's nothing stopping people from using it in normal Elm applications. Defaulting to an empty list will be safer.