### PR TITLE
Increase RandomRun max length from 32k to 64k

### DIFF
--- a/src/RandomRun.elm
+++ b/src/RandomRun.elm
@@ -49,7 +49,7 @@ a PRNG choice), like in:
 -}
 maxLength : Int
 maxLength =
-    32 * 1024
+    64 * 1024
 
 
 type alias Chunk =


### PR DESCRIPTION
In elm-in-elm/compiler, in an Expr fuzzer of max depth 3 with lists and strings hardcoded to length 5 this was maxing out.

Now of course the sensible solution was to make the length variable (1-5 etc). but this anecdote means the limit can be reached by more advanced fuzzers.

So let's raise the limit a bit? List of 64k integers still seems OK memory-hungriness-wise.