### PR TITLE
Point Selector types to exposed ones

### DIFF
--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -24,7 +24,8 @@ import Expect exposing (Expectation)
 import Html exposing (Html)
 import Test.Html.Internal.Inert as Inert
 import Test.Html.Query.Internal as Internal exposing (failWithQuery)
-import Test.Html.Selector.Internal exposing (Selector, selectorToString)
+import Test.Html.Selector exposing (Selector)
+import Test.Html.Selector.Internal exposing (selectorToString)
 
 
 


### PR DESCRIPTION
A few functions were referencing `Selector` in their arguments, but they were pointing to the one in `Internal` rather than the one that is publicly exposed.
This make it harder to find where Selectors are, and I can imagine that this makes adding type annotations through an IDE create an invalid type annotation (because it would reference something that wasn't exposed).

This was reported by the `NoMissingTypeExpose` `elm-review` rule.