### PR TITLE
Bumps max length

### DIFF
--- a/src/RandomRun.elm
+++ b/src/RandomRun.elm
@@ -49,7 +49,7 @@ a PRNG choice), like in:
 -}
 maxLength : Int
 maxLength =
-    64 * 1024
+    64 * 1024 * 1024
 
 
 type alias Chunk =


### PR DESCRIPTION
This makes it harder to hit the `Fuzz.rollDice: Your fuzzers have hit the max size of RandomRun (generating too much data).`