### PR TITLE
Fix imports in documentation examples

### DIFF
--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -578,9 +578,9 @@ equalSets expected actual =
 
 {-| Always passes.
 
+    import Expect
     import Json.Decode exposing (decodeString, int)
     import Test exposing (test)
-    import Expect
 
 
     test "Json.Decode.int can decode the number 42." <|
@@ -600,9 +600,9 @@ pass =
 
 {-| Fails with the given message.
 
+    import Expect
     import Json.Decode exposing (decodeString, int)
     import Test exposing (test)
-    import Expect
 
 
     test "Json.Decode.int can decode the number 42." <|

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -73,9 +73,9 @@ concat tests =
 
 {-| Apply a description to a list of tests.
 
-    import Test exposing (describe, test, fuzz)
-    import Fuzz exposing (int)
     import Expect
+    import Fuzz exposing (int)
+    import Test exposing (describe, fuzz, test)
 
 
     describe "List"
@@ -141,8 +141,8 @@ describe untrimmedDesc tests =
 {-| Return a [`Test`](#Test) that evaluates a single
 [`Expectation`](../Expect#Expectation).
 
-    import Test exposing (test)
     import Expect
+    import Test exposing (test)
 
 
     test "the empty list has 0 length" <|
@@ -276,9 +276,9 @@ skip =
 
 The number of times to run each fuzz test. (Default is 100.)
 
-    import Test exposing (fuzzWith, noDistribution)
-    import Fuzz exposing (list, int)
     import Expect
+    import Fuzz exposing (int, list)
+    import Test exposing (fuzzWith, noDistribution)
 
     fuzzWith { runs = 350, distribution = noDistribution }
         (list int)
@@ -297,10 +297,10 @@ The number of times to run each fuzz test. (Default is 100.)
 A way to report/enforce a statistical distribution of your input values.
 (Default is `noDistribution`.)
 
-    import Test exposing (fuzzWith, expectDistribution)
-    import Test.Distribution
-    import Fuzz exposing (list, int)
     import Expect
+    import Fuzz exposing (int, list)
+    import Test exposing (expectDistribution, fuzzWith)
+    import Test.Distribution
 
     fuzzWith
         { runs = 350
@@ -330,9 +330,9 @@ Note that there is no `fuzzWith2`, but you can always pass more fuzz values in
 using [`Fuzz.pair`](Fuzz#pair), [`Fuzz.triple`](Fuzz#triple),
 for example like this:
 
-    import Test exposing (fuzzWith, noDistribution)
-    import Fuzz exposing (pair, list, int)
     import Expect
+    import Fuzz exposing (int, list, pair)
+    import Test exposing (fuzzWith, noDistribution)
 
 
     fuzzWith { runs = 4200, distribution = noDistribution }
@@ -393,10 +393,9 @@ You may find them elsewhere called [property-based tests](http://blog.jessitron.
 [generative tests](http://www.pivotaltracker.com/community/tracker-blog/generative-testing), or
 [QuickCheck-style tests](https://en.wikipedia.org/wiki/QuickCheck).
 
-    import Test exposing (fuzz)
-    import Fuzz exposing (list, int)
     import Expect
-
+    import Fuzz exposing (int, list)
+    import Test exposing (fuzz)
 
     fuzz (list int) "List.length should never be negative" <|
         -- This anonymous function will be run 100 times, each time with a
@@ -422,9 +421,9 @@ This is a convenience function that lets you skip calling [`Fuzz.pair`](Fuzz#pai
 
 See [`fuzzWith`](#fuzzWith) for an example of writing this using tuples.
 
-    import Test exposing (fuzz2)
-    import Fuzz exposing (list, int)
     import Expect
+    import Fuzz exposing (int, list)
+    import Test exposing (fuzz2)
 
 
     fuzz2 (list int) int "List.reverse never influences List.member" <|

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -141,7 +141,7 @@ describe untrimmedDesc tests =
 {-| Return a [`Test`](#Test) that evaluates a single
 [`Expectation`](../Expect#Expectation).
 
-    import Test exposing (fuzz)
+    import Test exposing (test)
     import Expect
 
 
@@ -276,7 +276,7 @@ skip =
 
 The number of times to run each fuzz test. (Default is 100.)
 
-    import Test exposing (fuzzWith)
+    import Test exposing (fuzzWith, noDistribution)
     import Fuzz exposing (list, int)
     import Expect
 
@@ -297,7 +297,7 @@ The number of times to run each fuzz test. (Default is 100.)
 A way to report/enforce a statistical distribution of your input values.
 (Default is `noDistribution`.)
 
-    import Test exposing (fuzzWith)
+    import Test exposing (fuzzWith, expectDistribution)
     import Test.Distribution
     import Fuzz exposing (list, int)
     import Expect
@@ -330,7 +330,7 @@ Note that there is no `fuzzWith2`, but you can always pass more fuzz values in
 using [`Fuzz.pair`](Fuzz#pair), [`Fuzz.triple`](Fuzz#triple),
 for example like this:
 
-    import Test exposing (fuzzWith)
+    import Test exposing (fuzzWith, noDistribution)
     import Fuzz exposing (pair, list, int)
     import Expect
 
@@ -424,6 +424,7 @@ See [`fuzzWith`](#fuzzWith) for an example of writing this using tuples.
 
     import Test exposing (fuzz2)
     import Fuzz exposing (list, int)
+    import Expect
 
 
     fuzz2 (list int) int "List.reverse never influences List.member" <|

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -81,7 +81,7 @@ concat tests =
     describe "List"
         [ describe "reverse"
             [ test "has no effect on an empty list" <|
-                \_ ->
+                \() ->
                     List.reverse []
                         |> Expect.equal []
             , fuzz int "has no effect on a one-item list" <|
@@ -146,7 +146,7 @@ describe untrimmedDesc tests =
 
 
     test "the empty list has 0 length" <|
-        \_ ->
+        \() ->
             List.length []
                 |> Expect.equal 0
 
@@ -213,7 +213,7 @@ an `only` inside a `skip`, it will also get skipped.
         [ only <|
             describe "reverse"
                 [ test "has no effect on an empty list" <|
-                    \_ ->
+                    \() ->
                         List.reverse []
                             |> Expect.equal []
                 , fuzz int "has no effect on a one-item list" <|
@@ -222,7 +222,7 @@ an `only` inside a `skip`, it will also get skipped.
                             |> Expect.equal [ num ]
                 ]
         , test "This will not get run, because of the `only` above!" <|
-            \_ ->
+            \() ->
                 List.length []
                     |> Expect.equal 0
         ]
@@ -249,7 +249,7 @@ an `only` inside a `skip`, it will also get skipped.
         [ skip <|
             describe "reverse"
                 [ test "has no effect on an empty list" <|
-                    \_ ->
+                    \() ->
                         List.reverse []
                             |> Expect.equal []
                 , fuzz int "has no effect on a one-item list" <|
@@ -258,7 +258,7 @@ an `only` inside a `skip`, it will also get skipped.
                             |> Expect.equal [ num ]
                 ]
         , test "This is the only test that will get run; the other was skipped!" <|
-            \_ ->
+            \() ->
                 List.length []
                     |> Expect.equal 0
         ]

--- a/src/Test/Html/Event.elm
+++ b/src/Test/Html/Event.elm
@@ -54,7 +54,11 @@ type Event msg
 
 {-| Simulate an event on a node.
 
+    import Html
+    import Html.Events exposing (onInput)
+    import Test exposing (test)
     import Test.Html.Event as Event
+    import Test.Html.Query as Query
 
     type Msg
         = Change String
@@ -75,7 +79,11 @@ simulate =
 
 {-| Passes if the given message is triggered by the simulated event.
 
+    import Html
+    import Html.Events exposing (onInput)
+    import Test exposing (test)
     import Test.Html.Event as Event
+    import Test.Html.Query as Query
 
     type Msg
         = Change String
@@ -113,7 +121,11 @@ expect msg (Event event (QueryInternal.Single showTrace query)) =
 Note that Event.expect gives nicer messages; this is generally more useful
 when testing that an event handler is _not_ present.
 
+    import Html
+    import Html.Events exposing (onInput)
+    import Test exposing (test)
     import Test.Html.Event as Event
+    import Test.Html.Query as Query
 
 
     test "Input produces expected Msg" <|
@@ -309,9 +321,12 @@ focus =
 {-| Simulate a custom event. The `String` is the event name, and the `Value` is the event object
 the browser would send to the event listener callback.
 
-    import Test.Html.Event as Event
+    import Html
+    import Html.Events exposing (onInput)
     import Json.Encode as Encode exposing (Value)
-
+    import Test exposing (test)
+    import Test.Html.Event as Event
+    import Test.Html.Query as Query
 
     type Msg
         = Change String

--- a/src/Test/Html/Event.elm
+++ b/src/Test/Html/Event.elm
@@ -343,10 +343,10 @@ the browser would send to the event listener callback.
                           )
                         ]
             in
-                Html.input [ onInput Change ] [ ]
-                    |> Query.fromHtml
-                    |> Event.simulate (Event.custom "input" simulatedEventObject)
-                    |> Event.expect (Change "cats")
+            Html.input [ onInput Change ] [ ]
+                |> Query.fromHtml
+                |> Event.simulate (Event.custom "input" simulatedEventObject)
+                |> Event.expect (Change "cats")
 
 -}
 custom : String -> Value -> ( String, Value )

--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -71,8 +71,8 @@ type alias Multiple msg =
 typically begin.
 
     import Html
-    import Test.Html.Query as Query
     import Test exposing (test)
+    import Test.Html.Query as Query
     import Test.Html.Selector exposing (text)
 
 
@@ -100,12 +100,12 @@ fromHtml html =
 
 {-| Find the descendant elements which match all the given selectors.
 
-    import Html exposing (div, ul, li, text)
-    import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (tag)
     import Expect
+    import Html exposing (div, li, text, ul)
+    import Html.Attributes exposing (class)
+    import Test exposing (test)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (tag)
 
 
     test "The list has three items" <|
@@ -131,12 +131,12 @@ findAll selectors (Internal.Single showTrace query) =
 
 {-| Find the descendant elements of the result of `findAll` which match all the given selectors.
 
-    import Html exposing (a, button, div, ul, li)
-    import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (tag)
     import Expect
+    import Html exposing (a, button, div, li, ul)
+    import Html.Attributes exposing (class)
+    import Test exposing (test)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (tag)
 
 
     test "The list has three items" <|
@@ -167,12 +167,12 @@ keep selector (Internal.Multiple showTrace query) =
 
 {-| Return the matched element's immediate child elements.
 
-    import Html exposing (div, ul, li, text)
-    import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
     import Expect
+    import Html exposing (div, li, text, ul)
+    import Html.Attributes exposing (class)
+    import Test exposing (test)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The <ul> only has <li> children" <|
@@ -200,11 +200,11 @@ children selectors (Internal.Single showTrace query) =
 {-| Find exactly one descendant element which matches all the given selectors.
 If no descendants match, or if more than one matches, the test will fail.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, li, ul)
     import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The list has both the classes 'items' and 'active'" <|
@@ -233,11 +233,11 @@ will fail.
 
 `Query.first` is a shorthand for `Query.index 0` - they do the same thing.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, li, ul)
     import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The first <li> is called 'first item'" <|
@@ -271,11 +271,11 @@ will match the last element, and `Query.index -2` will match the second-to-last.
 
 If the index falls outside the bounds of the match, the test will fail.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, li, ul)
     import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The second <li> is called 'second item'" <|
@@ -306,12 +306,12 @@ index position (Internal.Multiple showTrace query) =
 
 {-| Expect the number of elements matching the query fits the given expectation.
 
-    import Html exposing (div, ul, li)
-    import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
-    import Test exposing (test)
-    import Test.Html.Selector exposing (tag)
     import Expect
+    import Html exposing (div, li, ul)
+    import Html.Attributes exposing (class)
+    import Test exposing (test)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (tag)
 
 
     test "The list has three items" <|
@@ -336,11 +336,11 @@ count expect ((Internal.Multiple showTrace query) as multiple) =
 
 {-| Expect the element to have at least one descendant matching each node in the list.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, li, ul)
     import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The list has two li: one with the text \"third item\" and \
@@ -410,11 +410,11 @@ collectResults listOfResults =
 
 {-| Expect the element to match all of the given selectors.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, li, ul)
     import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The list has both the classes 'items' and 'active'" <|
@@ -441,9 +441,9 @@ has selectors (Internal.Single showTrace query) =
 
     import Html exposing (div)
     import Html.Attributes as Attributes
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, class)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (class, tag)
 
 
     test "The div element has no progress-bar class" <|
@@ -467,11 +467,11 @@ hasNot selectors (Internal.Single showTrace query) =
 {-| Expect that a [`Single`](#Single) expectation will hold true for each of the
 [`Multiple`](#Multiple) matched elements.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, li, ul)
     import Html.Attributes exposing (class)
-    import Test.Html.Query as Query
     import Test exposing (test)
-    import Test.Html.Selector exposing (tag, classes)
+    import Test.Html.Query as Query
+    import Test.Html.Selector exposing (classes, tag)
 
 
     test "The list has both the classes 'items' and 'active'" <|

--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -100,7 +100,7 @@ fromHtml html =
 
 {-| Find the descendant elements which match all the given selectors.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, ul, li, text)
     import Html.Attributes exposing (class)
     import Test.Html.Query as Query
     import Test exposing (test)
@@ -131,7 +131,7 @@ findAll selectors (Internal.Single showTrace query) =
 
 {-| Find the descendant elements of the result of `findAll` which match all the given selectors.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (a, button, div, ul, li)
     import Html.Attributes exposing (class)
     import Test.Html.Query as Query
     import Test exposing (test)
@@ -154,7 +154,7 @@ findAll selectors (Internal.Single showTrace query) =
                 |> Query.keep ( tag "a" )
                 |> Expect.all
                     [ Query.each (Query.has [ tag "a" ])
-                    , Query.first >> Query.has [ text "first item" ]
+                    , Query.first >> Query.has [ Test.Html.Selector.text "first item" ]
                     ]
 
 -}
@@ -167,11 +167,12 @@ keep selector (Internal.Multiple showTrace query) =
 
 {-| Return the matched element's immediate child elements.
 
-    import Html exposing (div, ul, li)
+    import Html exposing (div, ul, li, text)
     import Html.Attributes exposing (class)
     import Test.Html.Query as Query
     import Test exposing (test)
     import Test.Html.Selector exposing (tag, classes)
+    import Expect
 
 
     test "The <ul> only has <li> children" <|


### PR DESCRIPTION
Some consistency improvements to the documentation:
- Add missing imports in examples
- Format more like elm-format would, most notably sorting imports
- Use `\() ->` instead of `\_ ->`