### PR TITLE
Support providing a fake Browser.Navigation.Key in tests

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "elm/browser": "1.0.1 <= v < 2.0.0",
         "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -16,3 +16,5 @@ function _Test_runThunk(thunk)
     return __Result_Err(err.toString());
   }
 }
+
+function _Test_navigationKey() {}

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -1,5 +1,6 @@
 module Test exposing
     ( Test, test
+    , withNavigationKey
     , describe, concat, todo, skip, only
     , fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions
     , Distribution, noDistribution, reportDistribution, expectDistribution
@@ -8,6 +9,7 @@ module Test exposing
 {-| A module containing functions for creating and managing tests.
 
 @docs Test, test
+@docs withNavigationKey
 
 
 ## Organizing Tests
@@ -22,6 +24,8 @@ module Test exposing
 
 -}
 
+import Browser.Navigation
+import Elm.Kernel.Test
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer)
 import Set
@@ -162,6 +166,34 @@ test untrimmedDesc thunk =
 
     else
         Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> thunk ()))
+
+
+{-| Provide a [`Browser.Navigation.Key`](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#Key)
+value to your tests.
+
+You might need such a key if you're testing functions where a key is contained in the arguments, for instance when using
+[`Browser.application`](https://package.elm-lang.org/packages/elm/browser/latest/Browser#application)
+and storing the key in the `Model`.
+
+    import Expect
+    import Test exposing (test)
+
+    Test.withNavigationKey <|
+        \key ->
+            test "functionToTest returns 0 when given 0" <|
+                \() ->
+                    functionToTest key 0
+                        |> Expect.equal 0
+
+-}
+withNavigationKey : (Browser.Navigation.Key -> Test) -> Test
+withNavigationKey testFn =
+    testFn testNavigationKey
+
+
+testNavigationKey : Browser.Navigation.Key
+testNavigationKey =
+    Elm.Kernel.Test.navigationKey
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests

--- a/tests/src/BrowserTests.elm
+++ b/tests/src/BrowserTests.elm
@@ -1,0 +1,54 @@
+module BrowserTests exposing (all)
+
+import Browser.Navigation
+import Expect
+import Fuzz
+import Test exposing (Test, describe)
+
+
+all : Test
+all =
+    Test.withNavigationKey <|
+        \navKey ->
+            Test.describe "Test.withNavigationKey"
+                [ regularTest navKey
+                , fuzzTest navKey
+                ]
+
+
+regularTest : Browser.Navigation.Key -> Test
+regularTest navKey =
+    Test.test "(regular test) storing, using or comparing the key should not have any noticeable effect" <|
+        \() ->
+            let
+                init : { navKey : Browser.Navigation.Key }
+                init =
+                    { navKey = navKey }
+            in
+            ( init, cmdsUsingKey navKey )
+                |> Tuple.first
+                |> Expect.equal { navKey = navKey }
+
+
+fuzzTest : Browser.Navigation.Key -> Test
+fuzzTest navKey =
+    Test.fuzz Fuzz.int "(fuzz) storing, using or comparing the key should not have any noticeable effect" <|
+        \number ->
+            let
+                init : { navKey : Browser.Navigation.Key, number : Int }
+                init =
+                    { navKey = navKey, number = number }
+            in
+            ( init, cmdsUsingKey navKey )
+                |> Tuple.first
+                |> Expect.equal { navKey = navKey, number = number }
+
+
+cmdsUsingKey : Browser.Navigation.Key -> Cmd msg
+cmdsUsingKey navKey =
+    Cmd.batch
+        [ Browser.Navigation.pushUrl navKey "some-url"
+        , Browser.Navigation.replaceUrl navKey "some-url"
+        , Browser.Navigation.back navKey 1
+        , Browser.Navigation.forward navKey 1
+        ]

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -1,5 +1,6 @@
 module Tests exposing (all)
 
+import BrowserTests
 import Expect
 import FloatWithinTests exposing (floatWithinTests)
 import Fuzz exposing (..)
@@ -28,6 +29,7 @@ all =
         , fuzzerTests
         , floatWithinTests
         , RunnerTests.all
+        , BrowserTests.all
         , elmHtmlTests
         , shrinkingChallenges
         , RandomRunTests.all


### PR DESCRIPTION
Closes #24

Adds `Test.withNavigationKey` which provide a [`Browser.Navigation.Key`](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Navigation#Key) to tests.

This functions is designed such that the key can't be used in production code in a way that will have a noticeable effect (one could generate a test in production code, but they can't really do anything with a test).

Without this, the workaround is to define a wrapper type
```elm
type Key
  = RealKey Browser.Navigation.Key
  | TestKey
```
as well as wrapper functions for `Browser.Navigation` functions (such as `pushUrl`) that accept this type, where they'll do nothing if the key is not a real key.

---

Implemention-wise, the key is a simple function with a side-effect and no input ([source](https://github.com/elm/browser/blob/1.0.2/src/Elm/Kernel/Browser.js#L146)).
I've introduced a new test key which is a plain noop function, which should be equivalent in all "noticeable" ways (even through `Debug.log`).

**Releasing this functionality will lock the implementation of `elm/browser`'s key to such a function**, at least until it releases a new major version.