### PR TITLE
Simplify expectations to a single expectation

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -161,7 +161,7 @@ test untrimmedDesc thunk =
         Internal.blankDescriptionFailure
 
     else
-        Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> [ thunk () ]))
+        Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> thunk ()))
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -52,16 +52,15 @@ validatedFuzzTest fuzzer getExpectation distribution =
             in
             case runResult.failure of
                 Nothing ->
-                    [ Pass { distributionReport = runResult.distributionReport } ]
+                    Pass { distributionReport = runResult.distributionReport }
 
                 Just failure ->
-                    [ { failure
+                    { failure
                         | expectation =
                             failure.expectation
                                 |> Test.Expectation.withDistributionReport runResult.distributionReport
-                      }
+                    }
                         |> formatExpectation
-                    ]
         )
 
 

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -14,8 +14,8 @@ For more information, see <https://github.com/elm-explorations/test/pull/153>
 
 -}
 type Test
-    = ElmTestVariant__UnitTest (() -> List Expectation)
-    | ElmTestVariant__FuzzTest (Random.Seed -> Int -> List Expectation)
+    = ElmTestVariant__UnitTest (() -> Expectation)
+    | ElmTestVariant__FuzzTest (Random.Seed -> Int -> Expectation)
     | ElmTestVariant__Labeled String Test
     | ElmTestVariant__Skipped Test
     | ElmTestVariant__Only Test
@@ -27,7 +27,7 @@ type Test
 failNow : { description : String, reason : Reason } -> Test
 failNow record =
     ElmTestVariant__UnitTest
-        (\() -> [ Test.Expectation.fail record ])
+        (\() -> Test.Expectation.fail record)
 
 
 blankDescriptionFailure : Test

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -62,14 +62,14 @@ import Test.Runner.Failure exposing (Reason(..))
 {-| An unevaluated test.
 -}
 type Runnable
-    = Thunk (() -> List Expectation)
+    = Thunk (() -> Expectation)
 
 
 {-| A function which, when evaluated, produces a list of expectations. Also a
 list of labels which apply to this outcome.
 -}
 type alias Runner =
-    { run : () -> List Expectation
+    { run : () -> Expectation
     , labels : List String
     }
 
@@ -136,14 +136,14 @@ countRunnables runnable =
             countRunnables runner
 
 
-run : Runnable -> List Expectation
+run : Runnable -> Expectation
 run (Thunk fn) =
     case runThunk fn of
         Ok test ->
             test
 
         Err message ->
-            [ Expect.fail ("This test failed because it threw an exception: \"" ++ message ++ "\"") ]
+            Expect.fail ("This test failed because it threw an exception: \"" ++ message ++ "\"")
 
 
 runThunk : (() -> a) -> Result String a

--- a/tests/src/Helpers.elm
+++ b/tests/src/Helpers.elm
@@ -161,8 +161,7 @@ expectTestToFail test =
     test
         |> Test.Runner.fromTest 100 seed
         |> getRunners
-        |> List.map (\{ run } -> run ())
-        |> List.map (\expectation () -> expectToFail expectation)
+        |> List.map (\{ run } () -> expectToFail (run ()))
         |> (\expectations -> Expect.all expectations ())
 
 

--- a/tests/src/Helpers.elm
+++ b/tests/src/Helpers.elm
@@ -82,9 +82,7 @@ testSimplifyingWith { runs } test =
             Test.test label <|
                 \() ->
                     runner.run ()
-                        |> List.head
-                        |> Maybe.map (passToFail handleFailure)
-                        |> Maybe.withDefault (Expect.fail "Somehow `testSimplifyingWith` had multiple tests inside")
+                        |> passToFail handleFailure
 
         _ ->
             Debug.todo "Unexpected number of test runners in `testSimplifyingWith`"
@@ -125,9 +123,7 @@ testFailingWith { runs } test =
             Test.test label <|
                 \() ->
                     runner.run ()
-                        |> List.head
-                        |> Maybe.map (passToFail handleFailure)
-                        |> Maybe.withDefault (Expect.fail "Somehow `testFailingWith` had multiple tests inside")
+                        |> passToFail handleFailure
 
         _ ->
             Debug.todo "Unexpected number of test runners in `testFailingWith`"
@@ -165,7 +161,7 @@ expectTestToFail test =
     test
         |> Test.Runner.fromTest 100 seed
         |> getRunners
-        |> List.concatMap (\{ run } -> run ())
+        |> List.map (\{ run } -> run ())
         |> List.map (\expectation () -> expectToFail expectation)
         |> (\expectations -> Expect.all expectations ())
 

--- a/tests/src/Runner/String.elm
+++ b/tests/src/Runner/String.elm
@@ -63,8 +63,7 @@ toOutputHelp runner summary =
                Debug.log "TEST" runner.labels
        in
     -}
-    runner.run ()
-        |> List.foldl (fromExpectation runner.labels) summary
+    fromExpectation runner.labels (runner.run ()) summary
 
 
 fromExpectation : List String -> Expectation -> Summary -> Summary

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -197,8 +197,7 @@ fromTest =
                     case toSeededRunners (test "crashes" <| \() -> Debug.todo "crash") of
                         Plain [ runner ] ->
                             runner.run ()
-                                |> List.head
-                                |> Maybe.andThen Test.Runner.getFailureReason
+                                |> Test.Runner.getFailureReason
                                 |> Expect.equal
                                     (Just
                                         { given = Nothing


### PR DESCRIPTION
Internally, the tests were expecting a list of `Expectation`, but it seems it's always a singleton list.
We can therefore remove the surrounding list, which simplifies the internals a bit.