### PR TITLE
Add golden file tests

### DIFF
--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -5,6 +5,7 @@ import Result exposing (Err, Ok)
 
 */
 
+const fs = require('fs');
 
 function _Test_runThunk(thunk)
 {
@@ -16,3 +17,26 @@ function _Test_runThunk(thunk)
     return __Result_Err(err.toString());
   }
 }
+
+function _Test_readFile(filePath)
+{
+    try {
+        return __Result_Ok(fs.readFileSync(filePath, { encoding: 'utf8' }));
+    }
+    catch (err)
+    {
+        return __Result_Err(err.toString())
+    }
+}
+
+var _Test_writeFile = F2(function(filePath, contents)
+{
+    try {
+        fs.writeFileSync(filePath, contents);
+        return __Result_Ok(__Utils_Tuple0);
+    }
+    catch (err)
+    {
+        return __Result_Err(err.toString());
+    }
+})

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -106,6 +106,36 @@ var _Test_writeFile = F2(function(filePath, contents)
     return WriteFile(path.resolve("tests"), filePath, contents);
 })
 
+function _Test_deleteFile(filePath)
+{
+    // Test for this early as `resolve` will strip training slashes
+    if (filePath.slice(-1) == path.sep) {
+        return __Result_Err(__File_IsDirectory);
+    }
+
+    // Protect against deleting files above the "tests" directory
+    const testsPath = path.resolve("tests");
+    const fullPath = path.resolve(testsPath, filePath);
+
+    if (!fullPath.startsWith(testsPath))
+    {
+        return __Result_Err(__File_PathEscapesDirectory);
+    }
+
+    try {
+        fs.unlinkSync(fullPath);
+    }
+    catch (err)
+    {
+        if (err.code == "ENOENT"){
+            return __Result_Err(__File_FileNotFound);
+        }
+        else {
+            return __Result_Err(__File_GeneralFileError(err.toString()));
+        }
+    }
+}
+
 var overwriteGoldenFiles = null;
 function _Test_overwriteGoldenFiles(unused)
 {

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -69,11 +69,8 @@ var _Test_writeFile = F2(function(filePath, contents)
 
     const fullDir = path.dirname(fullPath);
 
-    if (!fs.existsSync(fullDir))
-    {
-        // Can this make a nested directory? 
-        fs.mkdirSync(fullDir, {recursive: true});
-    }
+    // Note that this does not throw an error if the directory exists
+    fs.mkdirSync(fullDir, {recursive: true});
 
     try {
         fs.writeFileSync(fullPath, contents);

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -18,8 +18,8 @@ function _Test_runThunk(thunk)
 }
 
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function _Test_readFile(filePath)
 {

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -21,6 +21,7 @@ function _Test_runThunk(thunk)
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const process = require('node:process');
 const crypto = require('node:crypto');
 
 function _Test_readFile(filePath)
@@ -99,3 +100,12 @@ var _Test_writeTempFile = F2(function(filePath, contents)
 
     return WriteFile(tempDir, filePath, contents);
 })
+
+var overwriteGoldenFiles = null;
+function _Test_overwriteGoldenFiles(unused)
+{
+    if (overwriteGoldenFiles === null)
+        overwriteGoldenFiles = process.env.OVERWRITE_GOLDEN_FILES == '1';
+    
+    return overwriteGoldenFiles;
+}

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -20,9 +20,7 @@ function _Test_runThunk(thunk)
 
 const fs = require('node:fs');
 const path = require('node:path');
-const os = require('node:os');
 const process = require('node:process');
-const crypto = require('node:crypto');
 
 function _Test_readFile(filePath)
 {
@@ -69,6 +67,25 @@ function WriteFile(root, filePath, contents)
         return __Result_Err(__File_PathEscapesDirectory);
     }
 
+    // Remove failed file if it exists
+    var failedPath = null; 
+    if (!fullPath.endsWith(".failed.html") && fullPath.endsWith(".html")) 
+        failedPath = fullPath.slice(0, -5) + ".failed.html";
+    else if (!fullPath.endsWith(".failed"))
+        failedPath = fullPath + ".failed";
+
+    if (failedPath)
+    {
+        try
+        {
+            fs.unlinkSync(failedPath);
+        }
+        catch (error)
+        {
+            // Ignore failure if file doesn't exist
+        }
+    }
+        
     const fullDir = path.dirname(fullPath);
 
     // Note that this does not throw an error if the directory exists
@@ -87,18 +104,6 @@ function WriteFile(root, filePath, contents)
 var _Test_writeFile = F2(function(filePath, contents)
 {
     return WriteFile(path.resolve("tests"), filePath, contents);
-})
-
-var tempDir = null;
-var _Test_writeTempFile = F2(function(filePath, contents)
-{
-    if (tempDir === null)
-    {
-        tempDir = os.tmpdir() + "/" + crypto.randomUUID();
-        fs.mkdirSync(tempDir);
-    }
-
-    return WriteFile(tempDir, filePath, contents);
 })
 
 var overwriteGoldenFiles = null;

--- a/src/Elm/Kernel/Test.js
+++ b/src/Elm/Kernel/Test.js
@@ -1,11 +1,10 @@
 /*
 
 import Elm.Kernel.Utils exposing (Tuple0)
+import File exposing (FileNotFound, GeneralFileError, IsDirectory, PathEscapesDirectory)
 import Result exposing (Err, Ok)
 
 */
-
-const fs = require('fs');
 
 function _Test_runThunk(thunk)
 {
@@ -18,25 +17,70 @@ function _Test_runThunk(thunk)
   }
 }
 
+
+const fs = require('fs');
+const path = require('path');
+
 function _Test_readFile(filePath)
 {
+    // Test for this early as `resolve` will strip training slashes
+    if (filePath.slice(-1) == path.sep) {
+        return __Result_Err(__File_IsDirectory);
+    }
+
+    // Protect against reading files above the "tests" directory
+    const testsPath = path.resolve("tests");
+    const fullPath = path.resolve(testsPath, filePath);
+
+    if (!fullPath.startsWith(testsPath))
+    {
+        return __Result_Err(__File_PathEscapesDirectory);
+    }
+
     try {
-        return __Result_Ok(fs.readFileSync(filePath, { encoding: 'utf8' }));
+        return __Result_Ok(fs.readFileSync(fullPath, { encoding: 'utf8' }));
     }
     catch (err)
     {
-        return __Result_Err(err.toString())
+        if (err.code == "ENOENT"){
+            return __Result_Err(__File_FileNotFound);
+        }
+        else {
+            return __Result_Err(__File_GeneralFileError(err.toString()));
+        }
     }
 }
 
 var _Test_writeFile = F2(function(filePath, contents)
 {
+    // Test for this early as `resolve` will strip training slashes
+    if (filePath.slice(-1) == path.sep) {
+        return __Result_Err(__File_IsDirectory);
+    }
+
+    // Protect against writing files above the "tests" directory
+    const testsPath = path.resolve("tests");
+    const fullPath = path.resolve(testsPath, filePath);
+
+    if (!fullPath.startsWith(testsPath))
+    {
+        return __Result_Err(__File_PathEscapesDirectory);
+    }
+
+    const fullDir = path.dirname(fullPath);
+
+    if (!fs.existsSync(fullDir))
+    {
+        // Can this make a nested directory? 
+        fs.mkdirSync(fullDir, {recursive: true});
+    }
+
     try {
-        fs.writeFileSync(filePath, contents);
+        fs.writeFileSync(fullPath, contents);
         return __Result_Ok(__Utils_Tuple0);
     }
     catch (err)
-    {
-        return __Result_Err(err.toString());
+    {   
+        return __Result_Err(__File_GeneralFileError(err.toString()));
     }
 })

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -3,7 +3,7 @@ module Expect exposing
     , lessThan, atMost, greaterThan, atLeast
     , FloatingPointTolerance(..), within, notWithin
     , ok, err, equalLists, equalDicts, equalSets
-    , pass, fail, onFail
+    , pass, fail, onFail, equalToFile
     )
 
 {-| A library to create `Expectation`s, which describe a claim to be tested.
@@ -575,6 +575,25 @@ equalSets expected actual =
         in
         reportCollectionFailure "Expect.equalSets" expected actual missingKeys extraKeys
 
+readFile : String -> Result String String
+readFile = Elm.Kernel.Test.readFile
+
+writeFile : String -> String -> Result String ()
+writeFile = Elm.Kernel.Test.writeFile
+
+equalToFile : String -> String -> Expectation
+equalToFile filePath actual =
+    case readFile filePath of 
+        Err _ ->
+            case writeFile filePath actual of 
+                Err q -> 
+                    fail q
+
+                Ok _ ->
+                    pass
+
+        Ok contents -> 
+            equateWith ("equalToFile \'" ++ filePath ++ "\'") (==) contents actual
 
 {-| Always passes.
 

--- a/src/Expect.elm
+++ b/src/Expect.elm
@@ -635,7 +635,16 @@ equalToFile filePath actual =
                     pass
 
                 else
-                    case File.writeTempFile filePath actual of
+                    let
+                        failedFilePath =
+                            -- Be careful to make the failed final extension .html so that browsers can render it
+                            if String.endsWith ".html" filePath then
+                                String.dropRight (String.length ".html") filePath ++ ".failed.html"
+
+                            else
+                                filePath ++ ".failed"
+                    in
+                    case File.writeFile failedFilePath actual of
                         Ok newAbsolutePath ->
                             let
                                 message =

--- a/src/File.elm
+++ b/src/File.elm
@@ -1,4 +1,4 @@
-module File exposing (AbsolutePath, FileError(..), RelativePath, readFile, writeFile, writeTempFile)
+module File exposing (AbsolutePath, FileError(..), RelativePath, overwriteGoldenFiles, readFile, writeFile, writeTempFile)
 
 import Elm.Kernel.Test
 
@@ -43,3 +43,10 @@ Returns the absolute file path if successful.
 writeTempFile : RelativePath -> String -> Result FileError AbsolutePath
 writeTempFile =
     Elm.Kernel.Test.writeTempFile
+
+
+{-| Checks the OVERWRITE\_GOLDEN\_FILES environment variable
+-}
+overwriteGoldenFiles : () -> Bool
+overwriteGoldenFiles =
+    Elm.Kernel.Test.overwriteGoldenFiles

--- a/src/File.elm
+++ b/src/File.elm
@@ -1,4 +1,4 @@
-module File exposing (AbsolutePath, FileError(..), RelativePath, overwriteGoldenFiles, readFile, writeFile)
+module File exposing (AbsolutePath, FileError(..), RelativePath, overwriteGoldenFiles, readFile, writeFile, deleteFile)
 
 import Elm.Kernel.Test
 
@@ -34,6 +34,10 @@ writeFile : RelativePath -> String -> Result FileError AbsolutePath
 writeFile =
     Elm.Kernel.Test.writeFile
 
+{-| Delete the file specified in filePath relative to "tests/" -}
+deleteFile : RelativePath -> Result FileError ()
+deleteFile = 
+    Elm.Kernel.Test.deleteFile
 
 {-| Checks the OVERWRITE\_GOLDEN\_FILES environment variable
 -}

--- a/src/File.elm
+++ b/src/File.elm
@@ -1,4 +1,4 @@
-module File exposing (AbsolutePath, FileError(..), RelativePath, overwriteGoldenFiles, readFile, writeFile, writeTempFile)
+module File exposing (AbsolutePath, FileError(..), RelativePath, overwriteGoldenFiles, readFile, writeFile)
 
 import Elm.Kernel.Test
 
@@ -33,16 +33,6 @@ Returns the absolute file path if successful.
 writeFile : RelativePath -> String -> Result FileError AbsolutePath
 writeFile =
     Elm.Kernel.Test.writeFile
-
-
-{-| Write the contents of the second argument to the file path in the first argument relative to a temp directory
-
-Returns the absolute file path if successful.
-
--}
-writeTempFile : RelativePath -> String -> Result FileError AbsolutePath
-writeTempFile =
-    Elm.Kernel.Test.writeTempFile
 
 
 {-| Checks the OVERWRITE\_GOLDEN\_FILES environment variable

--- a/src/File.elm
+++ b/src/File.elm
@@ -1,0 +1,15 @@
+module File exposing (readFile, writeFile, FileError(..))
+
+import Elm.Kernel.Test
+
+type FileError
+    = FileNotFound
+    | IsDirectory
+    | PathEscapesDirectory
+    | GeneralFileError String
+
+readFile : String -> Result FileError String
+readFile = Elm.Kernel.Test.readFile
+
+writeFile : String -> String -> Result FileError ()
+writeFile = Elm.Kernel.Test.writeFile

--- a/src/File.elm
+++ b/src/File.elm
@@ -1,6 +1,7 @@
-module File exposing (readFile, writeFile, FileError(..))
+module File exposing (AbsolutePath, FileError(..), RelativePath, readFile, writeFile, writeTempFile)
 
 import Elm.Kernel.Test
+
 
 type FileError
     = FileNotFound
@@ -8,8 +9,37 @@ type FileError
     | PathEscapesDirectory
     | GeneralFileError String
 
-readFile : String -> Result FileError String
-readFile = Elm.Kernel.Test.readFile
 
-writeFile : String -> String -> Result FileError ()
-writeFile = Elm.Kernel.Test.writeFile
+type alias RelativePath =
+    String
+
+
+type alias AbsolutePath =
+    String
+
+
+{-| Read the contents of the filePath relative to "tests/"
+-}
+readFile : RelativePath -> Result FileError ( AbsolutePath, String )
+readFile =
+    Elm.Kernel.Test.readFile
+
+
+{-| Write the contents of the second argument to the file path in the first argument relative to "tests/"
+
+Returns the absolute file path if successful.
+
+-}
+writeFile : RelativePath -> String -> Result FileError AbsolutePath
+writeFile =
+    Elm.Kernel.Test.writeFile
+
+
+{-| Write the contents of the second argument to the file path in the first argument relative to a temp directory
+
+Returns the absolute file path if successful.
+
+-}
+writeTempFile : RelativePath -> String -> Result FileError AbsolutePath
+writeTempFile =
+    Elm.Kernel.Test.writeTempFile

--- a/src/Test/Html/Query.elm
+++ b/src/Test/Html/Query.elm
@@ -2,6 +2,7 @@ module Test.Html.Query exposing
     ( Single, Multiple, fromHtml
     , find, findAll, children, first, index, keep
     , count, contains, has, hasNot, each
+    , prettyPrintSingle
     )
 
 {-| Querying HTML structure.
@@ -17,6 +18,10 @@ module Test.Html.Query exposing
 ## Expecting
 
 @docs count, contains, has, hasNot, each
+
+## Debugging
+
+@docs prettyPrintSingle
 
 -}
 
@@ -496,3 +501,16 @@ each : (Single msg -> Expectation) -> Multiple msg -> Expectation
 each check (Internal.Multiple showTrace query) =
     Internal.expectAll check query
         |> failWithQuery showTrace "Query.each" query
+
+{-| Pretty prints the result of a query as HTML if successful -}
+prettyPrintSingle : Single msg -> Result String String
+prettyPrintSingle (Internal.Single _ query) =
+    case Internal.traverse query of 
+        Ok [ element ] -> 
+            Ok <| Internal.prettyPrint element
+
+        Ok results -> 
+            Err <| "Query.prettyPrintSingle expected exactly one result from query, but found " ++ String.fromInt (List.length results)
+
+        Err queryError -> 
+            Err <| "Query.prettyPrintSingle " ++ Internal.queryErrorToString queryError


### PR DESCRIPTION
This PR adds a new primitive equalToFile to the Expect module. It also adds a prettyPrintSingle method

This primitive allows us to write golden file / snapshot tests in Elm. These are particularly useful at capturing the current outputs of a program and then failing if the outputs change.

NoRedInk in particular has an interest in snapshotting the HTML at various points in elm-tests to a file. I've also added a prettyPrintSingle function to the query module which exposes the internal query pretty print function. I think this will be useful generally for testing to be able to capture focus of a query in a complicated test (especially with elm-program-test). NRI would also see value in dumping the entire HTML of a page to a golden file so that we can do visual diffs of our pages in their various states.

Note that the code its current state is very rough - the kernel code added presumes that the tests are being run in the context of a node environment. That's always true for [node-test-runner](https://github.com/rtfeldman/node-test-runner) but AFAIK not always true for [elm-test-rs](https://github.com/mpizenberg/elm-test-rs). I'm very open to any ideas that would make this more robust.

I'm also aware that doing the IO direclty inside of the elm-explorations/test probably prevents the test runners from doing proper watching on these golden files. Definitely open to ideas on approaches that would let the actual file IO be handled by the runner itself.