### PR TITLE
Simplify expectations to a single expectation

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -161,7 +161,7 @@ test untrimmedDesc thunk =
         Internal.blankDescriptionFailure
 
     else
-        Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> [ thunk () ]))
+        Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> thunk ()))
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests

--- a/src/Test/Fuzz.elm
+++ b/src/Test/Fuzz.elm
@@ -61,16 +61,15 @@ validatedFuzzTest desc fuzzer getExpectation distribution =
             in
             case runResult.failure of
                 Nothing ->
-                    [ Pass { distributionReport = runResult.distributionReport } ]
+                    Pass { distributionReport = runResult.distributionReport }
 
                 Just failure ->
-                    [ { failure
+                    { failure
                         | expectation =
                             failure.expectation
                                 |> Test.Expectation.withDistributionReport runResult.distributionReport
-                      }
+                    }
                         |> formatExpectation
-                    ]
         )
 
 

--- a/src/Test/Internal.elm
+++ b/src/Test/Internal.elm
@@ -14,8 +14,8 @@ For more information, see <https://github.com/elm-explorations/test/pull/153>
 
 -}
 type Test
-    = ElmTestVariant__UnitTest (() -> List Expectation)
-    | ElmTestVariant__FuzzTest (Random.Seed -> Int -> List Expectation)
+    = ElmTestVariant__UnitTest (() -> Expectation)
+    | ElmTestVariant__FuzzTest (Random.Seed -> Int -> Expectation)
     | ElmTestVariant__Labeled String Test
     | ElmTestVariant__Skipped Test
     | ElmTestVariant__Only Test
@@ -27,7 +27,7 @@ type Test
 failNow : { description : String, reason : Reason } -> Test
 failNow record =
     ElmTestVariant__UnitTest
-        (\() -> [ Test.Expectation.fail record ])
+        (\() -> Test.Expectation.fail record)
 
 
 blankDescriptionFailure : Test

--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -62,11 +62,15 @@ import Test.Runner.Failure exposing (Reason(..))
 {-| An unevaluated test.
 -}
 type Runnable
-    = Thunk (() -> List Expectation)
+    = Thunk (() -> Expectation)
 
 
 {-| A function which, when evaluated, produces a list of expectations. Also a
 list of labels which apply to this outcome.
+
+NOTE: Even though a list is returned, that list only ever contains exactly one
+expectation. Changing it to return just `Expectation` would be a breaking change.
+
 -}
 type alias Runner =
     { run : () -> List Expectation
@@ -136,14 +140,14 @@ countRunnables runnable =
             countRunnables runner
 
 
-run : Runnable -> List Expectation
+run : Runnable -> Expectation
 run (Thunk fn) =
     case runThunk fn of
         Ok test ->
             test
 
         Err message ->
-            [ Expect.fail ("This test failed because it threw an exception: \"" ++ message ++ "\"") ]
+            Expect.fail ("This test failed because it threw an exception: \"" ++ message ++ "\"")
 
 
 runThunk : (() -> a) -> Result String a
@@ -161,7 +165,7 @@ fromRunnableTreeHelp labels runner =
     case runner of
         Runnable runnable ->
             [ { labels = labels
-              , run = \_ -> run runnable
+              , run = \_ -> [ run runnable ]
               }
             ]
 


### PR DESCRIPTION
This is the same as #244, except I didn’t change the public API. We go with a single expectation internally for as long as we can, and only turn that into a singleton list when we hit the public API boundary.

```
❯ elm diff
No API changes detected, so this is a PATCH change.
```