### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       # Clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       # Setup Node JS
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
 
       # Install elm and cache ELM_HOME
       - name: Install elm
-        uses: mpizenberg/elm-tooling-action@v1.7
+        uses: mpizenberg/elm-tooling-action@v2
         with:
           cache-key: tests-${{ matrix.os }}-node${{ matrix.node }}-0
           cache-restore-key: tests-${{ matrix.os }}-node${{ matrix.node }}
@@ -46,11 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Clone the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
       # Install elm-format
       - name: Install elm-format
-        uses: mpizenberg/elm-tooling-action@v1.7
+        uses: mpizenberg/elm-tooling-action@v2
         with:
           cache-key: format-${{ matrix.os }}-node${{ matrix.node }}-0
           cache-restore-key: format-${{ matrix.os }}-node${{ matrix.node }}


### PR DESCRIPTION
CI failed in https://github.com/elm-explorations/test/pull/254:

```
Run mpizenberg/elm-tooling-action@v1.7
(node:1169) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
/Users/runner/work/test/test/elm-tooling.json

tools["elm"]
    Unknown version: 0.19.2
Error: Failed to install tools
    Known versions: 0.19.0, 0.19.1
```

Also there is this warning:

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This PR updates all actions to the latest version, which fixes the above problems.