### PR TITLE
Support nested Test.only

### DIFF
--- a/src/Test/Runner.elm
+++ b/src/Test/Runner.elm
@@ -329,8 +329,12 @@ distributeSeedsHelp hashed runs seed test =
                 next =
                     distributeSeedsHelp hashed runs seed subTest
             in
-            -- `only` all the things!
-            { next | only = next.all }
+            if List.isEmpty next.only then
+                -- `only` all the things!
+                { next | only = next.all }
+
+            else
+                { next | only = next.only }
 
         Internal.ElmTestVariant__Batch tests ->
             List.foldl (batchDistribute hashed runs) (emptyDistribution seed) tests

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -34,7 +34,7 @@ all =
 
                             else
                                 Expect.fail ("Expected a run count of " ++ String.fromInt runs ++ " to be invalid, but was valid with this value: " ++ Debug.toString val)
-            , test "an only inside another only has no effect" <|
+            , test "an only inside another only should ignore the non-only siblings" <|
                 \_ ->
                     let
                         suite =
@@ -51,9 +51,43 @@ all =
                         Only runners ->
                             runners
                                 |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "three tests", "two tests", "is an only" ] ]
+
+                        val ->
+                            Expect.fail ("Expected SeededRunner to be Only, but was " ++ Debug.toString val)
+            , test "should keep all only tests spread among siblings" <|
+                \_ ->
+                    let
+                        suite =
+                            describe "root"
+                                [ test "A" expectPass
+                                , describe "B"
+                                    [ Test.only (test "1" testImpl)
+                                    ]
+                                , Test.only <|
+                                    describe "C"
+                                        [ test "1" testImpl
+                                        , Test.only (test "2" testImpl)
+                                        , describe "3"
+                                            [ test "X" testImpl
+                                            , Test.only (test "Y" testImpl)
+                                            , test "Z" testImpl
+                                            ]
+                                        ]
+                                , describe "D"
+                                    [ Test.only (test "1" testImpl)
+                                    ]
+                                ]
+                    in
+                    case toSeededRunners suite of
+                        Only runners ->
+                            runners
+                                |> List.map (.labels >> List.reverse)
                                 |> Expect.equal
-                                    [ [ "three tests", "two tests", "fails" ]
-                                    , [ "three tests", "two tests", "is an only" ]
+                                    [ [ "root", "B", "1" ]
+                                    , [ "root", "C", "2" ]
+                                    , [ "root", "C", "3", "Y" ]
+                                    , [ "root", "D", "1" ]
                                     ]
 
                         val ->
@@ -180,7 +214,7 @@ all =
                                 |> Expect.equal
                                     (Just
                                         { given = Nothing
-                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 174\n\ncrash\""
+                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 208\n\ncrash\""
                                         , reason = Test.Runner.Failure.Custom
                                         }
                                     )

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -9,19 +9,13 @@ import Test.Runner exposing (SeededRunners(..))
 import Test.Runner.Failure
 
 
-all : Test
-all =
-    Test.concat
-        [ fromTest ]
-
-
 toSeededRunners : Test -> SeededRunners
 toSeededRunners =
     Test.Runner.fromTest 5 (Random.initialSeed 42)
 
 
-fromTest : Test
-fromTest =
+all : Test
+all =
     describe "TestRunner.fromTest"
         [ describe "test length"
             [ fuzz2 int int "only positive tests runs are valid" <|
@@ -186,7 +180,7 @@ fromTest =
                                 |> Expect.equal
                                     (Just
                                         { given = Nothing
-                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 180\n\ncrash\""
+                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 174\n\ncrash\""
                                         , reason = Test.Runner.Failure.Custom
                                         }
                                     )

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -49,11 +49,8 @@ fromTest =
                                     [ test "passes" expectPass
                                     , Test.only <|
                                         describe "two tests"
-                                            [ test "fails" <|
-                                                \_ -> Expect.fail "failed on purpose"
-                                            , Test.only <|
-                                                test "is an only" <|
-                                                    \_ -> Expect.fail "failed on purpose"
+                                            [ test "fails" testImpl
+                                            , Test.only (test "is an only" testImpl)
                                             ]
                                     ]
                     in
@@ -77,11 +74,8 @@ fromTest =
                                     [ test "passes" expectPass
                                     , Test.only <|
                                         describe "two tests"
-                                            [ test "fails" <|
-                                                \_ -> Expect.fail "failed on purpose"
-                                            , Test.skip <|
-                                                test "is skipped" <|
-                                                    \_ -> Expect.fail "failed on purpose"
+                                            [ test "fails" testImpl
+                                            , Test.skip (test "is skipped" testImpl)
                                             ]
                                     ]
                     in
@@ -102,11 +96,8 @@ fromTest =
                                     [ test "passes" expectPass
                                     , Test.skip <|
                                         describe "two tests"
-                                            [ test "fails" <|
-                                                \_ -> Expect.fail "failed on purpose"
-                                            , Test.only <|
-                                                test "is skipped" <|
-                                                    \_ -> Expect.fail "failed on purpose"
+                                            [ test "fails" testImpl
+                                            , Test.only (test "is skipped" testImpl)
                                             ]
                                     ]
                     in
@@ -137,11 +128,8 @@ fromTest =
                                     [ test "passes" expectPass
                                     , Test.skip <|
                                         describe "two tests"
-                                            [ test "fails" <|
-                                                \_ -> Expect.fail "failed on purpose"
-                                            , Test.skip <|
-                                                test "is skipped" <|
-                                                    \_ -> Expect.fail "failed on purpose"
+                                            [ test "fails" testImpl
+                                            , Test.skip (test "is skipped" testImpl)
                                             ]
                                     ]
                     in
@@ -160,9 +148,7 @@ fromTest =
                             toSeededRunners <|
                                 describe "two tests"
                                     [ test "passes" expectPass
-                                    , Test.skip <|
-                                        test "fails" <|
-                                            \_ -> Expect.fail "failed on purpose"
+                                    , Test.skip (test "fails" testImpl)
                                     ]
                     in
                     case seededRunners of
@@ -222,3 +208,10 @@ fromTest =
 passing : Test
 passing =
     test "A passing test" expectPass
+
+
+{-| Dummy test implementation.
+-}
+testImpl : () -> Expect.Expectation
+testImpl () =
+    Expect.pass

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -43,18 +43,17 @@ fromTest =
             , test "an only inside another only has no effect" <|
                 \_ ->
                     let
-                        seededRunners =
-                            toSeededRunners <|
-                                describe "three tests"
-                                    [ test "passes" expectPass
-                                    , Test.only <|
-                                        describe "two tests"
-                                            [ test "fails" testImpl
-                                            , Test.only (test "is an only" testImpl)
-                                            ]
-                                    ]
+                        suite =
+                            describe "three tests"
+                                [ test "passes" expectPass
+                                , Test.only <|
+                                    describe "two tests"
+                                        [ test "fails" testImpl
+                                        , Test.only (test "is an only" testImpl)
+                                        ]
+                                ]
                     in
-                    case seededRunners of
+                    case toSeededRunners suite of
                         Only runners ->
                             runners
                                 |> List.map (.labels >> List.reverse)
@@ -68,18 +67,17 @@ fromTest =
             , test "a skip inside an only takes effect" <|
                 \_ ->
                     let
-                        seededRunners =
-                            toSeededRunners <|
-                                describe "three tests"
-                                    [ test "passes" expectPass
-                                    , Test.only <|
-                                        describe "two tests"
-                                            [ test "fails" testImpl
-                                            , Test.skip (test "is skipped" testImpl)
-                                            ]
-                                    ]
+                        suite =
+                            describe "three tests"
+                                [ test "passes" expectPass
+                                , Test.only <|
+                                    describe "two tests"
+                                        [ test "fails" testImpl
+                                        , Test.skip (test "is skipped" testImpl)
+                                        ]
+                                ]
                     in
-                    case seededRunners of
+                    case toSeededRunners suite of
                         Only runners ->
                             runners
                                 |> List.map (.labels >> List.reverse)
@@ -90,18 +88,17 @@ fromTest =
             , test "an only inside a skip has no effect" <|
                 \_ ->
                     let
-                        seededRunners =
-                            toSeededRunners <|
-                                describe "three tests"
-                                    [ test "passes" expectPass
-                                    , Test.skip <|
-                                        describe "two tests"
-                                            [ test "fails" testImpl
-                                            , Test.only (test "is skipped" testImpl)
-                                            ]
-                                    ]
+                        suite =
+                            describe "three tests"
+                                [ test "passes" expectPass
+                                , Test.skip <|
+                                    describe "two tests"
+                                        [ test "fails" testImpl
+                                        , Test.only (test "is skipped" testImpl)
+                                        ]
+                                ]
                     in
-                    case seededRunners of
+                    case toSeededRunners suite of
                         Skipping runners ->
                             runners
                                 |> List.map (.labels >> List.reverse)
@@ -122,18 +119,17 @@ fromTest =
             , test "a skip inside another skip has no effect" <|
                 \_ ->
                     let
-                        seededRunners =
-                            toSeededRunners <|
-                                describe "three tests"
-                                    [ test "passes" expectPass
-                                    , Test.skip <|
-                                        describe "two tests"
-                                            [ test "fails" testImpl
-                                            , Test.skip (test "is skipped" testImpl)
-                                            ]
-                                    ]
+                        suite =
+                            describe "three tests"
+                                [ test "passes" expectPass
+                                , Test.skip <|
+                                    describe "two tests"
+                                        [ test "fails" testImpl
+                                        , Test.skip (test "is skipped" testImpl)
+                                        ]
+                                ]
                     in
-                    case seededRunners of
+                    case toSeededRunners suite of
                         Skipping runners ->
                             runners
                                 |> List.map (.labels >> List.reverse)
@@ -144,14 +140,13 @@ fromTest =
             , test "a pair of tests where one uses skip is a Skipping summary" <|
                 \_ ->
                     let
-                        seededRunners =
-                            toSeededRunners <|
-                                describe "two tests"
-                                    [ test "passes" expectPass
-                                    , Test.skip (test "fails" testImpl)
-                                    ]
+                        suite =
+                            describe "two tests"
+                                [ test "passes" expectPass
+                                , Test.skip (test "fails" testImpl)
+                                ]
                     in
-                    case seededRunners of
+                    case toSeededRunners suite of
                         Skipping runners ->
                             runners
                                 |> List.map (.labels >> List.reverse)
@@ -191,7 +186,7 @@ fromTest =
                                 |> Expect.equal
                                     (Just
                                         { given = Nothing
-                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 199\n\ncrash\""
+                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 180\n\ncrash\""
                                         , reason = Test.Runner.Failure.Custom
                                         }
                                     )

--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -60,8 +60,11 @@ fromTest =
                     case seededRunners of
                         Only runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 2
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal
+                                    [ [ "three tests", "two tests", "fails" ]
+                                    , [ "three tests", "two tests", "is an only" ]
+                                    ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Only, but was " ++ Debug.toString val)
@@ -85,8 +88,8 @@ fromTest =
                     case seededRunners of
                         Only runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 1
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "three tests", "two tests", "fails" ] ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Only, but was " ++ Debug.toString val)
@@ -110,8 +113,8 @@ fromTest =
                     case seededRunners of
                         Skipping runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 1
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "three tests", "passes" ] ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ Debug.toString val)
@@ -120,8 +123,8 @@ fromTest =
                     case toSeededRunners (Test.only <| test "passes" expectPass) of
                         Only runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 1
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "passes" ] ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Only, but was " ++ Debug.toString val)
@@ -145,8 +148,8 @@ fromTest =
                     case seededRunners of
                         Skipping runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 1
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "three tests", "passes" ] ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ Debug.toString val)
@@ -165,8 +168,8 @@ fromTest =
                     case seededRunners of
                         Skipping runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 1
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "two tests", "passes" ] ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Skipping, but was " ++ Debug.toString val)
@@ -185,8 +188,8 @@ fromTest =
                     case toSeededRunners (test "passes" expectPass) of
                         Plain runners ->
                             runners
-                                |> List.length
-                                |> Expect.equal 1
+                                |> List.map (.labels >> List.reverse)
+                                |> Expect.equal [ [ "passes" ] ]
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Plain, but was " ++ Debug.toString val)
@@ -202,7 +205,7 @@ fromTest =
                                 |> Expect.equal
                                     (Just
                                         { given = Nothing
-                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 196\n\ncrash\""
+                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 199\n\ncrash\""
                                         , reason = Test.Runner.Failure.Custom
                                         }
                                     )


### PR DESCRIPTION
Fixes #128 #253 and https://github.com/rtfeldman/node-test-runner/issues/638

Starts with a few clean up commits to make tests more precise and then simpler.