### PR TITLE
Add `repeat` for parametrized tests and fuzz test examples

### DIFF
--- a/src/Test.elm
+++ b/src/Test.elm
@@ -3,7 +3,7 @@ module Test exposing
     , describe, concat, todo, skip, only
     , fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions
     , Distribution, noDistribution, reportDistribution, expectDistribution
-    , repeat, testWith
+    , repeat, testWithValue
     )
 
 {-| A module containing functions for creating and managing tests.
@@ -24,7 +24,7 @@ module Test exposing
 
 ## Repeating Tests
 
-@docs repeat, testWith
+@docs repeat, testWithValue
 
 -}
 
@@ -572,10 +572,10 @@ This is useful if you want to run the same test with different inputs – also
 known as _parametrized tests:_
 
     repeat "checking if a string is whitespace only"
-        [ testWith "empty string" { input = "", expected = True }
-        , testWith "space, newline, tab" { input = " \n\t", expected = True }
-        , testWith "only non-whitespace" { input = "a", expected = False }
-        , testWith "mixed" { input = "a b", expected = False }
+        [ testWithValue "empty string" { input = "", expected = True }
+        , testWithValue "space, newline, tab" { input = " \n\t", expected = True }
+        , testWithValue "only non-whitespace" { input = "a", expected = False }
+        , testWithValue "mixed" { input = "a b", expected = False }
         ]
     <|
         \{ input, expected } ->
@@ -596,7 +596,7 @@ guarantee that specific input will ever be generated again. In this case, you
 can use `repeat` to save such inputs as explicit regression tests:
 
     repeat "String.words never returns an empty list"
-        [ testWith "only whitespace" " \n\t"
+        [ testWithValue "only whitespace" " \n\t"
         , fuzz Fuzz.string "fuzz"
         ]
     <|
@@ -611,7 +611,7 @@ If you want to [skip](#skip) tests, or focus on tests with [only](#only), use
 function composition (`<<`):
 
     repeat "String.words never returns an empty list"
-        [ only << testWith "only whitespace" " \n\t"
+        [ only << testWithValue "only whitespace" " \n\t"
         , fuzz Fuzz.string "fuzz"
         ]
     <|
@@ -628,8 +628,8 @@ repeat desc tests thunk =
 {-| This is a small wrapper around [test](#test), which is supposed to be used with [repeat](#repeat).
 See that function for examples.
 -}
-testWith : String -> a -> (a -> Expectation) -> Test
-testWith desc a thunk =
+testWithValue : String -> a -> (a -> Expectation) -> Test
+testWithValue desc a thunk =
     test desc (\() -> thunk a)
 
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -572,10 +572,10 @@ This is useful if you want to run the same test with different inputs – also
 known as _parametrized tests:_
 
     repeat "checking if a string is whitespace only"
-        [ testWith { input = "", expected = True } "empty string"
-        , testWith { input = " \n\t", expected = True } "space, newline, tab"
-        , testWith { input = "a", expected = False } "only non-whitespace"
-        , testWith { input = "a b", expected = False } "mixed"
+        [ testWith "empty string" { input = "", expected = True }
+        , testWith "space, newline, tab" { input = " \n\t", expected = True }
+        , testWith "only non-whitespace" { input = "a", expected = False }
+        , testWith "mixed" { input = "a b", expected = False }
         ]
     <|
         \{ input, expected } ->
@@ -596,7 +596,7 @@ guarantee that specific input will ever be generated again. In this case, you
 can use `repeat` to save such inputs as explicit regression tests:
 
     repeat "String.words never returns an empty list"
-        [ testWith " \n\t" "only whitespace"
+        [ testWith "only whitespace" " \n\t"
         , fuzz Fuzz.string "fuzz"
         ]
     <|
@@ -611,7 +611,7 @@ If you want to [skip](#skip) tests, or focus on tests with [only](#only), use
 function composition (`<<`):
 
     repeat "String.words never returns an empty list"
-        [ only << testWith " \n\t" "only whitespace"
+        [ only << testWith "only whitespace" " \n\t"
         , fuzz Fuzz.string "fuzz"
         ]
     <|
@@ -628,8 +628,8 @@ repeat desc tests thunk =
 {-| This is a small wrapper around [test](#test), which is supposed to be used with [repeat](#repeat).
 See that function for examples.
 -}
-testWith : a -> String -> (a -> Expectation) -> Test
-testWith a desc thunk =
+testWith : String -> a -> (a -> Expectation) -> Test
+testWith desc a thunk =
     test desc (\() -> thunk a)
 
 

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -1,13 +1,13 @@
 module Test exposing
-    ( Test, test
+    ( Test, test, parametrized
     , describe, concat, todo, skip, only
-    , fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions
+    , fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions, fuzzWithExamples
     , Distribution, noDistribution, reportDistribution, expectDistribution
     )
 
 {-| A module containing functions for creating and managing tests.
 
-@docs Test, test
+@docs Test, test, parametrized
 
 
 ## Organizing Tests
@@ -17,7 +17,7 @@ module Test exposing
 
 ## Fuzz Testing
 
-@docs fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions
+@docs fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions, fuzzWithExamples
 @docs Distribution, noDistribution, reportDistribution, expectDistribution
 
 -}
@@ -162,6 +162,36 @@ test untrimmedDesc thunk =
 
     else
         Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> thunk ()))
+
+
+{-| Runs a single test many times with a list of given inputs.
+
+    import Expect
+    import Test exposing (parametrized)
+
+
+    parametrized
+        [ ( "negative", { input = -1, expected = LT } )
+        , ( "zero", { input = 0, expected = EQ } )
+        , ( "positive", { input = 1, expected = GT } )
+        ]
+        "compare with zero"
+    <|
+        \{ input, expected } ->
+            compare input 0
+                |> Expect.equal expected
+
+The strings in the tuples are used as labels to make it easier to tell which test failed.
+The values in the tuples can be anything you like. In this example we used records to
+easily specify the input value the the expected outcome.
+
+If you are looking for this but for a fuzz test, see [fuzzWithExamples](#fuzzWithExamples).
+
+-}
+parametrized : List ( String, a ) -> String -> (a -> Expectation) -> Test
+parametrized cases desc thunk =
+    describe desc
+        (List.map (\( name, value ) -> test name (\() -> thunk value)) cases)
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests
@@ -381,6 +411,58 @@ fuzzWithHelp options aTest =
             tests
                 |> List.map (fuzzWithHelp options)
                 |> Internal.ElmTestVariant__Batch
+
+
+{-| This is the combination of [fuzzWith](#fuzzWith) and [parametrized](#parametrized).
+
+In addition to running the fuzz test, run the same test with a few hardcoded examples.
+When the fuzz test fails, you might want to add that case to the examples as a regression test.
+That specific input might never be picked randomly again!
+
+    import Expect
+    import Fuzz exposing (float)
+    import Test exposing (fuzzWithExamples, noDistribution)
+
+
+    fuzzWithExamples { runs = 100, distribution = noDistribution }
+        float
+        [ ( "NaN", 0 / 0 )
+        , ( "Infinity", 1 / 0 )
+        ]
+        "compare with zero is only EQ when input also is zero"
+    <|
+        \input ->
+            let
+                expect =
+                    if input == 0 && input == input then
+                        Expect.equal
+
+                    else
+                        Expect.notEqual
+            in
+            compare input 0
+                |> expect EQ
+
+-}
+fuzzWithExamples : FuzzOptions a -> Fuzzer a -> List ( String, a ) -> String -> (a -> Expectation) -> Test
+fuzzWithExamples options fuzzer examples desc getTest =
+    let
+        labels =
+            List.map Tuple.first examples |> Set.fromList
+
+        -- Just in case the examples are `[ ( "fuzz", a ), ( "fuzz_", b ) ]`.
+        -- Sibling tests can’t have the same label.
+        fuzzLabel label =
+            if Set.member label labels then
+                fuzzLabel (label ++ "_")
+
+            else
+                label
+    in
+    describe desc
+        (List.map (\( name, value ) -> test name (\() -> getTest value)) examples
+            ++ [ fuzzWith options fuzzer (fuzzLabel "fuzz") getTest ]
+        )
 
 
 {-| Take a function that produces a test, and calls it several (usually 100) times, using a randomly-generated input

--- a/src/Test.elm
+++ b/src/Test.elm
@@ -1,13 +1,14 @@
 module Test exposing
-    ( Test, test, parametrized
+    ( Test, test
     , describe, concat, todo, skip, only
-    , fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions, fuzzWithExamples
+    , fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions
     , Distribution, noDistribution, reportDistribution, expectDistribution
+    , repeat, testWith
     )
 
 {-| A module containing functions for creating and managing tests.
 
-@docs Test, test, parametrized
+@docs Test, test
 
 
 ## Organizing Tests
@@ -17,8 +18,13 @@ module Test exposing
 
 ## Fuzz Testing
 
-@docs fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions, fuzzWithExamples
+@docs fuzz, fuzz2, fuzz3, fuzzWith, FuzzOptions
 @docs Distribution, noDistribution, reportDistribution, expectDistribution
+
+
+## Repeating Tests
+
+@docs repeat, testWith
 
 -}
 
@@ -162,36 +168,6 @@ test untrimmedDesc thunk =
 
     else
         Internal.ElmTestVariant__Labeled desc (Internal.ElmTestVariant__UnitTest (\() -> thunk ()))
-
-
-{-| Runs a single test many times with a list of given inputs.
-
-    import Expect
-    import Test exposing (parametrized)
-
-
-    parametrized
-        [ ( "negative", { input = -1, expected = LT } )
-        , ( "zero", { input = 0, expected = EQ } )
-        , ( "positive", { input = 1, expected = GT } )
-        ]
-        "compare with zero"
-    <|
-        \{ input, expected } ->
-            compare input 0
-                |> Expect.equal expected
-
-The strings in the tuples are used as labels to make it easier to tell which test failed.
-The values in the tuples can be anything you like. In this example we used records to
-easily specify the input value the the expected outcome.
-
-If you are looking for this but for a fuzz test, see [fuzzWithExamples](#fuzzWithExamples).
-
--}
-parametrized : List ( String, a ) -> String -> (a -> Expectation) -> Test
-parametrized cases desc thunk =
-    describe desc
-        (List.map (\( name, value ) -> test name (\() -> thunk value)) cases)
 
 
 {-| Returns a [`Test`](#Test) that is "TODO" (not yet implemented). These tests
@@ -413,58 +389,6 @@ fuzzWithHelp options aTest =
                 |> Internal.ElmTestVariant__Batch
 
 
-{-| This is the combination of [fuzzWith](#fuzzWith) and [parametrized](#parametrized).
-
-In addition to running the fuzz test, run the same test with a few hardcoded examples.
-When the fuzz test fails, you might want to add that case to the examples as a regression test.
-That specific input might never be picked randomly again!
-
-    import Expect
-    import Fuzz exposing (float)
-    import Test exposing (fuzzWithExamples, noDistribution)
-
-
-    fuzzWithExamples { runs = 100, distribution = noDistribution }
-        float
-        [ ( "NaN", 0 / 0 )
-        , ( "Infinity", 1 / 0 )
-        ]
-        "compare with zero is only EQ when input also is zero"
-    <|
-        \input ->
-            let
-                expect =
-                    if input == 0 && input == input then
-                        Expect.equal
-
-                    else
-                        Expect.notEqual
-            in
-            compare input 0
-                |> expect EQ
-
--}
-fuzzWithExamples : FuzzOptions a -> Fuzzer a -> List ( String, a ) -> String -> (a -> Expectation) -> Test
-fuzzWithExamples options fuzzer examples desc getTest =
-    let
-        labels =
-            List.map Tuple.first examples |> Set.fromList
-
-        -- Just in case the examples are `[ ( "fuzz", a ), ( "fuzz_", b ) ]`.
-        -- Sibling tests can’t have the same label.
-        fuzzLabel label =
-            if Set.member label labels then
-                fuzzLabel (label ++ "_")
-
-            else
-                label
-    in
-    describe desc
-        (List.map (\( name, value ) -> test name (\() -> getTest value)) examples
-            ++ [ fuzzWith options fuzzer (fuzzLabel "fuzz") getTest ]
-        )
-
-
 {-| Take a function that produces a test, and calls it several (usually 100) times, using a randomly-generated input
 from a [`Fuzzer`](http://package.elm-lang.org/packages/elm-explorations/test/latest/Fuzz) each time. This allows you to
 test that a property that should always be true is indeed true under a wide variety of conditions. The function also
@@ -638,6 +562,75 @@ Currently the statistical test is tuned to allow a false positive/negative in
 expectDistribution : List ( ExpectedDistribution, String, a -> Bool ) -> Distribution a
 expectDistribution =
     Test.Distribution.Internal.ExpectDistribution
+
+
+{-| This is like [describe](#describe), but all the tests use the same function.
+Just like with `describe`, you pass a list of tests – but they are missing their
+function to run! Instead, the function that all tests will be run with comes last.
+
+This is useful if you want to run the same test with different inputs – also
+known as _parametrized tests:_
+
+    repeat "checking if a string is whitespace only"
+        [ testWith { input = "", expected = True } "empty string"
+        , testWith { input = " \n\t", expected = True } "space, newline, tab"
+        , testWith { input = "a", expected = False } "only non-whitespace"
+        , testWith { input = "a b", expected = False } "mixed"
+        ]
+    <|
+        \{ input, expected } ->
+            let
+                isOnlyWhitespace =
+                    String.words input == [ "" ]
+            in
+            isOnlyWhitespace
+                |> Expect.equal expected
+
+In the above example we passed a record with `input` and `expected` to each test,
+but you can pass whatever you want.
+
+You can also use this for [fuzz](#fuzz) tests. Let’s say your fuzz test found an
+issue after a _long_ time, and you fix it. Do you have confidence it will never
+regress? After all, finding the issue took some amount of luck, and there is no
+guarantee that specific input will ever be generated again. In this case, you
+can use `repeat` to save such inputs as explicit regression tests:
+
+    repeat "String.words never returns an empty list"
+        [ testWith " \n\t" "only whitespace"
+        , fuzz Fuzz.string "fuzz"
+        ]
+    <|
+        \string ->
+            String.words string
+                |> Expect.notEqual []
+
+Having a few hardcoded examples for a fuzz test can also be useful to highlight
+important cases.
+
+If you want to [skip](#skip) tests, or focus on tests with [only](#only), use
+function composition (`<<`):
+
+    repeat "String.words never returns an empty list"
+        [ only << testWith " \n\t" "only whitespace"
+        , fuzz Fuzz.string "fuzz"
+        ]
+    <|
+        \string ->
+            String.words string
+                |> Expect.notEqual []
+
+-}
+repeat : String -> List ((a -> Expectation) -> Test) -> (a -> Expectation) -> Test
+repeat desc tests thunk =
+    describe desc (List.map (\toTest -> toTest thunk) tests)
+
+
+{-| This is a small wrapper around [test](#test), which is supposed to be used with [repeat](#repeat).
+See that function for examples.
+-}
+testWith : a -> String -> (a -> Expectation) -> Test
+testWith a desc thunk =
+    test desc (\() -> thunk a)
 
 
 

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -210,11 +210,11 @@ testTests =
                         |> expectTestToFail
             , test "fails with empty name" <|
                 \() ->
-                    repeat "" [ testWith () "x" ] expectPass
+                    repeat "" [ testWith "x" () ] expectPass
                         |> expectTestToFail
             , test "fails with empty sub name" <|
                 \() ->
-                    repeat "x" [ testWith () "" ] expectPass
+                    repeat "x" [ testWith "" () ] expectPass
                         |> expectTestToFail
             ]
         , identicalNamesAreRejectedTests

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -210,11 +210,11 @@ testTests =
                         |> expectTestToFail
             , test "fails with empty name" <|
                 \() ->
-                    repeat "" [ testWith "x" () ] expectPass
+                    repeat "" [ testWithValue "x" () ] expectPass
                         |> expectTestToFail
             , test "fails with empty sub name" <|
                 \() ->
-                    repeat "x" [ testWith "" () ] expectPass
+                    repeat "x" [ testWithValue "" () ] expectPass
                         |> expectTestToFail
             ]
         , identicalNamesAreRejectedTests

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -170,6 +170,20 @@ testTests =
                     test "" expectPass
                         |> expectTestToFail
             ]
+        , describe "parametrized"
+            [ test "fails with empty list" <|
+                \() ->
+                    parametrized [] "x" expectPass
+                        |> expectTestToFail
+            , test "fails with empty name" <|
+                \() ->
+                    parametrized [ ( "x", () ) ] "" expectPass
+                        |> expectTestToFail
+            , test "fails with empty sub name" <|
+                \() ->
+                    parametrized [ ( "", () ) ] "" expectPass
+                        |> expectTestToFail
+            ]
         , describe "fuzz"
             [ test "fails with empty name" <|
                 \() ->
@@ -190,6 +204,32 @@ testTests =
                         Fuzz.bool
                         ""
                         expectPass
+                        |> expectTestToFail
+            ]
+        , describe "fuzzWithExamples"
+            [ test "fails with fewer than 1 run" <|
+                \() ->
+                    fuzzWithExamples { runs = 0, distribution = noDistribution }
+                        Fuzz.bool
+                        []
+                        "nonpositive"
+                        expectPass
+                        |> expectTestToFail
+            , test "fails with empty name" <|
+                \() ->
+                    fuzzWithExamples { runs = 1, distribution = noDistribution }
+                        Fuzz.bool
+                        []
+                        ""
+                        expectPass
+                        |> expectTestToFail
+            , test "fails with empty sub name" <|
+                \() ->
+                    fuzzWithExamples { runs = 1, distribution = noDistribution }
+                        Fuzz.int
+                        [ ( "", 987461349871874 ) ]
+                        "x"
+                        (\n -> n |> Expect.equal 987461349871874)
                         |> expectTestToFail
             ]
         , describe "Test.todo"

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -170,20 +170,6 @@ testTests =
                     test "" expectPass
                         |> expectTestToFail
             ]
-        , describe "parametrized"
-            [ test "fails with empty list" <|
-                \() ->
-                    parametrized [] "x" expectPass
-                        |> expectTestToFail
-            , test "fails with empty name" <|
-                \() ->
-                    parametrized [ ( "x", () ) ] "" expectPass
-                        |> expectTestToFail
-            , test "fails with empty sub name" <|
-                \() ->
-                    parametrized [ ( "", () ) ] "" expectPass
-                        |> expectTestToFail
-            ]
         , describe "fuzz"
             [ test "fails with empty name" <|
                 \() ->
@@ -206,32 +192,6 @@ testTests =
                         expectPass
                         |> expectTestToFail
             ]
-        , describe "fuzzWithExamples"
-            [ test "fails with fewer than 1 run" <|
-                \() ->
-                    fuzzWithExamples { runs = 0, distribution = noDistribution }
-                        Fuzz.bool
-                        []
-                        "nonpositive"
-                        expectPass
-                        |> expectTestToFail
-            , test "fails with empty name" <|
-                \() ->
-                    fuzzWithExamples { runs = 1, distribution = noDistribution }
-                        Fuzz.bool
-                        []
-                        ""
-                        expectPass
-                        |> expectTestToFail
-            , test "fails with empty sub name" <|
-                \() ->
-                    fuzzWithExamples { runs = 1, distribution = noDistribution }
-                        Fuzz.int
-                        [ ( "", 987461349871874 ) ]
-                        "x"
-                        (\n -> n |> Expect.equal 987461349871874)
-                        |> expectTestToFail
-            ]
         , describe "Test.todo"
             [ test "causes test failure" <|
                 \() ->
@@ -242,6 +202,20 @@ testTests =
             , test "Simple failures are not TODO" <|
                 \_ ->
                     Expect.fail "reason" |> Test.Runner.isTodo |> Expect.equal False
+            ]
+        , describe "repeat"
+            [ test "fails with empty list" <|
+                \() ->
+                    repeat "x" [] expectPass
+                        |> expectTestToFail
+            , test "fails with empty name" <|
+                \() ->
+                    repeat "" [ testWith () "x" ] expectPass
+                        |> expectTestToFail
+            , test "fails with empty sub name" <|
+                \() ->
+                    repeat "x" [ testWith () "" ] expectPass
+                        |> expectTestToFail
             ]
         , identicalNamesAreRejectedTests
         ]


### PR DESCRIPTION
This PR adds a small convenience function called `repeat` (and one called `testWith`, which is `test` but shaped to fit `repeat`). This does not unlock anything that wasn’t already possible in user land – it’s all about convenience and teaching.

Me and @Janiczek were chatting, and Martin mentioned that when a fuzz test failed, he was missing a convenient way of adding that case as a regression test. `repeat` to the rescue!

```elm
    repeat "String.words never returns an empty list"
        [ testWith " \n\t" "only whitespace" -- regression test
        , fuzz Fuzz.string "fuzz"
        ]
    <|
        \string ->
            String.words string
                |> Expect.notEqual []
```

What I really like about this solution (and that I haven’t seen in ad-hoc implementations of this in test suites):

- You can use `skip` and `only`. No commenting out stuff in the list!
- IDE:s have a chance to find a location for each sub test. Ad-hoc implementations typically take a list of data – instead of using test functions in the list, like above – which means that there isn’t an “anchor” for each test that IDE:s can use. Also, by having this in the package, IDE:s have blessed names to look for (in addition to `test`, `fuzz`, `describe` etc.), whereas user land functions don’t really have that possibility.