### PR TITLE
Isolate runtime exception tests

### DIFF
--- a/tests/src/RunnerTests.elm
+++ b/tests/src/RunnerTests.elm
@@ -6,7 +6,6 @@ import Helpers exposing (expectPass)
 import Random
 import Test exposing (..)
 import Test.Runner exposing (SeededRunners(..))
-import Test.Runner.Failure
 
 
 all : Test
@@ -187,28 +186,6 @@ fromTest =
                             runners
                                 |> List.length
                                 |> Expect.equal 1
-
-                        val ->
-                            Expect.fail ("Expected SeededRunner to be Plain, but was " ++ Debug.toString val)
-            ]
-        , describe "catching exceptions"
-            [ test "when a test raises an exception, it is turned into a failure" <|
-                \() ->
-                    case toSeededRunners (test "crashes" <| \() -> Debug.todo "crash") of
-                        Plain [ runner ] ->
-                            runner.run ()
-                                |> List.head
-                                |> Maybe.andThen Test.Runner.getFailureReason
-                                |> Expect.equal
-                                    (Just
-                                        { given = Nothing
-                                        , description = "This test failed because it threw an exception: \"Error: TODO in module `RunnerTests` on line 196\n\ncrash\""
-                                        , reason = Test.Runner.Failure.Custom
-                                        }
-                                    )
-
-                        Plain runners ->
-                            Expect.fail ("Expected SeededRunner to have one runner, but had " ++ Debug.toString runners)
 
                         val ->
                             Expect.fail ("Expected SeededRunner to be Plain, but was " ++ Debug.toString val)

--- a/tests/src/RuntimeExceptionTests.elm
+++ b/tests/src/RuntimeExceptionTests.elm
@@ -1,0 +1,41 @@
+module RuntimeExceptionTests exposing (all)
+
+import Expect
+import Random
+import Test exposing (..)
+import Test.Runner exposing (SeededRunners(..))
+import Test.Runner.Failure
+
+
+toSeededRunners : Test -> SeededRunners
+toSeededRunners =
+    Test.Runner.fromTest 5 (Random.initialSeed 42)
+
+
+all : Test
+all =
+    describe "catching exceptions"
+        [ test "when a test raises an exception, it is turned into a failure" <|
+            \() ->
+                case toSeededRunners (test "crashes" <| \() -> Debug.todo "crash") of
+                    Plain [ runner ] ->
+                        runner.run ()
+                            |> List.head
+                            |> Maybe.andThen Test.Runner.getFailureReason
+                            |> Expect.equal
+                                (Just
+                                    { given = Nothing
+
+                                    -- The line number is currently off-by-one because we use Elm 0.19.2 and it has a bug:
+                                    -- https://github.com/elm/compiler/issues/2358
+                                    , description = "This test failed because it threw an exception: \"Error: TODO in module `RuntimeExceptionTests` on line 19\n\ncrash\""
+                                    , reason = Test.Runner.Failure.Custom
+                                    }
+                                )
+
+                    Plain runners ->
+                        Expect.fail ("Expected SeededRunner to have one runner, but had " ++ Debug.toString runners)
+
+                    val ->
+                        Expect.fail ("Expected SeededRunner to be Plain, but was " ++ Debug.toString val)
+        ]

--- a/tests/src/Tests.elm
+++ b/tests/src/Tests.elm
@@ -7,6 +7,7 @@ import FuzzerTests exposing (fuzzerTests)
 import Helpers exposing (..)
 import RandomRunTests
 import RunnerTests
+import RuntimeExceptionTests
 import ShrinkingChallengeTests exposing (shrinkingChallenges)
 import Test exposing (..)
 import Test.Html.EventTests
@@ -28,6 +29,7 @@ all =
         , fuzzerTests
         , floatWithinTests
         , RunnerTests.all
+        , RuntimeExceptionTests.all
         , elmHtmlTests
         , shrinkingChallenges
         , RandomRunTests.all


### PR DESCRIPTION
The test uses `Debug.todo` which contains the line number of that `Debug.todo` in the error message. Having this test below a bunch of other tests is annoying, because if you make changes to one of the earlier tests, you might move the `Debug.todo` up or down a few lines and then have to update the expected error message.

This PR moves the runtime exception tests to their own file, decreasing the probability of having to update it due to unrelated changes.